### PR TITLE
style: fix rustfmt CI

### DIFF
--- a/crates/impetus-client/src/lib.rs
+++ b/crates/impetus-client/src/lib.rs
@@ -155,7 +155,9 @@ impl EventSubscription for InMemoryEventSubscription {
                 // Wait for notification for our session
                 loop {
                     match self.notification_receiver.recv().await {
-                        Ok((notified_session_id, _sequence)) if notified_session_id == self.session_id => {
+                        Ok((notified_session_id, _sequence))
+                            if notified_session_id == self.session_id =>
+                        {
                             break;
                         }
                         Ok(_) => continue, // Different session

--- a/crates/impetus-core/src/storage.rs
+++ b/crates/impetus-core/src/storage.rs
@@ -174,7 +174,9 @@ impl EventStore for MemoryEventStore {
                 source_event.payload.clone(),
             );
             events.push(new_event.clone());
-            let _ = self.notifier.send((new_event.session_id, new_event.sequence));
+            let _ = self
+                .notifier
+                .send((new_event.session_id, new_event.sequence));
         }
 
         Ok(new_session_id)
@@ -378,7 +380,9 @@ impl EventStore for SqliteEventStore {
                 source_event.payload.clone(),
             );
             insert_event(&transaction, &new_event)?;
-            let _ = self.notifier.send((new_event.session_id, new_event.sequence));
+            let _ = self
+                .notifier
+                .send((new_event.session_id, new_event.sequence));
         }
 
         transaction.commit()?;

--- a/crates/impetus/src/main.rs
+++ b/crates/impetus/src/main.rs
@@ -105,7 +105,8 @@ async fn serve_client(stream: UnixStream, harness: Arc<Harness>) -> Result<()> {
     let mut reader = BufReader::new(reader);
     let mut negotiated = None::<BTreeSet<String>>;
     let mut subscription = None;
-    let mut notification_receiver: Option<tokio::sync::broadcast::Receiver<(uuid::Uuid, u64)>> = None;
+    let mut notification_receiver: Option<tokio::sync::broadcast::Receiver<(uuid::Uuid, u64)>> =
+        None;
     loop {
         tokio::select! {
             result = async {


### PR DESCRIPTION
Applies the exact rustfmt output reported by CI for main.rs, impetus-client/src/lib.rs, and storage.rs.