### PR TITLE
feat: implement policy-gated agent vertical slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Zap keeps its own UI as another `HarnessClient` consumer. See
   store raw tokens.
 - Typed Rust client transport, a reference CLI, ACP gateway library, and an
   experimental Zap integration baseline.
+- Agent-loop vertical for filesystem reads plus approval-gated writes and shell
+  commands; each result is persisted before it is returned to the model.
 
 ## Request control flow
 
@@ -108,6 +110,10 @@ In another terminal, create a session and interact:
 impetus create
 impetus prompt <session-id> "Summarize this repository"
 impetus stream <session-id>
+# When the stream shows a pending approval:
+impetus approve <session-id> <approval-id>
+# Or reject it and let the model continue with the denial observation:
+impetus approve <session-id> <approval-id> --reject
 ```
 
 For provider configuration, see [configuration docs](docs/configuration.md).

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,10 @@
 # TODO — Impetus Harness
 
-Исполнимая карта работ. Контекст: [ARCHITECTURE.md](ARCHITECTURE.md),
+Executable work map. Context: [ARCHITECTURE.md](ARCHITECTURE.md),
 [docs/ROADMAP.md](docs/ROADMAP.md).
 
-**Правило:** `[x]` только при working vertical slice + tests + gate. Stubs и
-placeholder responses не считаются done.
+**Rule:** mark `[x]` only after a working vertical slice, tests, and its gate.
+Stubs and placeholder responses do not count as done.
 
 ---
 
@@ -19,7 +19,7 @@ placeholder responses не считаются done.
 - [x] Typed `Action` with `origin=user|agent` and request ID tracking
 - [x] Sandbox integration for shell/process capabilities
 - [x] Attachment/diff/detail DTO contracts with bounded ephemeral/in-memory backing (not durable `ArtifactStore`)
-- [x] Agent Loop / Tool Orchestrator **skeleton only** — types and wiring; `extract_tool_calls()` and real tool execution are placeholders (see Phase 5)
+- [x] Agent Loop / Tool Orchestrator vertical slice: durable observations, policy-gated read tools, and exact approval/resume for writes and shell commands (see Phase 5)
 - [x] `ModelProvider` trait and `ProviderRegistry` foundation
 - [x] Crate split: `impetus-core`, `impetusd`, `impetus` (initial)
 
@@ -202,17 +202,17 @@ Upstream: `https://github.com/1jehuang/jcode` — pin SHA before implementation.
 
 ### Agent loop (real implementation)
 
-Skeleton/foundation exists; not a working autonomous loop yet.
+The baseline vertical is working. The remaining items harden and extend it.
 
 - [x] Replace `extract_tool_calls()` placeholder with provider-aware parsing
-- [ ] Wire Tool Orchestrator to real tool execution through policy/sandbox path
-- [ ] Durable observations from executed tools (not stub responses)
-- [ ] End-to-end slice: model → tool request → execution → observation → model
+- [x] Wire Tool Orchestrator to real tool execution through policy/sandbox path
+- [x] Durable observations from executed tools (not stub responses)
+- [x] End-to-end slice: model → tool request → execution → observation → model
 - [ ] Wire web research tools through `WebResearchService` (when WEB slice lands)
 
 ### Agent loop hardening
 
-- [ ] Multi-turn conversation state with tool result accumulation
+- [x] Multi-turn conversation state with durable tool result accumulation and approval/rejection resume
 - [ ] Streaming response chunking and client sync
 - [ ] Error recovery and retry logic (respect `UnknownOutcome` / `RETRY_BLOCKED`)
 - [ ] Parallel tool execution where safe (read_only/idempotent only)

--- a/crates/impetus-cli/src/main.rs
+++ b/crates/impetus-cli/src/main.rs
@@ -56,8 +56,9 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Commands::Create => {
+            let workspace_root = std::env::current_dir()?.canonicalize()?;
             let response = client
-                .request(impetus_core::IpcRequest::CreateSession)
+                .request(impetus_core::IpcRequest::CreateSession { workspace_root })
                 .await?;
             match response {
                 impetus_core::IpcResponse::Session { session_id, status } => {

--- a/crates/impetus-cli/src/main.rs
+++ b/crates/impetus-cli/src/main.rs
@@ -25,6 +25,16 @@ enum Commands {
         /// Session ID to cancel
         session_id: Uuid,
     },
+    /// Approve or reject a pending agent action
+    Approve {
+        /// Session that owns the approval
+        session_id: Uuid,
+        /// Pending approval ID
+        approval_id: Uuid,
+        /// Reject the pending action instead of approving it
+        #[arg(long)]
+        reject: bool,
+    },
     /// Send a prompt to a session
     Prompt {
         /// Session ID to prompt
@@ -105,6 +115,28 @@ async fn main() -> Result<()> {
                 other => bail!("Unexpected response: {other:?}"),
             }
         }
+        Commands::Approve {
+            session_id,
+            approval_id,
+            reject,
+        } => {
+            let response = client
+                .request(impetus_core::IpcRequest::ResolveApproval {
+                    session_id,
+                    approval_id,
+                    accepted: !reject,
+                })
+                .await?;
+            match response {
+                impetus_core::IpcResponse::ApprovalResolved { .. } => {
+                    println!("Approval {approval_id} resolved for session {session_id}");
+                }
+                impetus_core::IpcResponse::Error { message, .. } => {
+                    bail!("Error resolving approval: {message}");
+                }
+                other => bail!("Unexpected response: {other:?}"),
+            }
+        }
         Commands::Prompt { session_id, text } => {
             let response = client
                 .request(impetus_core::IpcRequest::Prompt { session_id, text })
@@ -165,5 +197,23 @@ mod tests {
         let id = Uuid::new_v4();
         let cli = Cli::try_parse_from(["impetus-cli", "context", &id.to_string()]).unwrap();
         assert!(matches!(cli.command, Commands::Context { session_id } if session_id == id));
+    }
+
+    #[test]
+    fn parses_rejected_approval() {
+        let session_id = Uuid::new_v4();
+        let approval_id = Uuid::new_v4();
+        let cli = Cli::try_parse_from([
+            "impetus-cli",
+            "approve",
+            &session_id.to_string(),
+            &approval_id.to_string(),
+            "--reject",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Approve { reject: true, .. }
+        ));
     }
 }

--- a/crates/impetus-client/src/lib.rs
+++ b/crates/impetus-client/src/lib.rs
@@ -16,6 +16,7 @@ use impetus_core::{
     PolicyEngine,
 };
 use std::future::Future;
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -45,8 +46,11 @@ pub trait HarnessClient: Send + Sync {
     async fn request(&self, request: IpcRequest) -> Result<IpcResponse>;
 
     /// Create a durable session owned by the harness.
-    async fn create_session(&self) -> Result<uuid::Uuid> {
-        match self.request(IpcRequest::CreateSession).await? {
+    async fn create_session(&self, workspace_root: PathBuf) -> Result<uuid::Uuid> {
+        match self
+            .request(IpcRequest::CreateSession { workspace_root })
+            .await?
+        {
             IpcResponse::Session { session_id, .. } => Ok(session_id),
             IpcResponse::Error { message, .. } => bail!(message),
             response => bail!("unexpected response: {response:?}"),
@@ -288,7 +292,10 @@ mod tests {
                 .any(|capability| capability == "context")
         );
 
-        let session_id = client.create_session().await.unwrap();
+        let session_id = client
+            .create_session(std::env::current_dir().unwrap().canonicalize().unwrap())
+            .await
+            .unwrap();
 
         let context = client.get_context(session_id).await.unwrap();
         assert!(
@@ -298,7 +305,11 @@ mod tests {
 
         let mut subscription = client.subscribe_live(session_id, 0).await.unwrap();
         let events = subscription.next_events().await.unwrap();
-        assert_eq!(events.len(), 1, "session-created event is backfilled once");
+        assert_eq!(
+            events.len(),
+            2,
+            "session creation and workspace are backfilled"
+        );
 
         // Read-only tool path still denies escaping the workspace.
         let outcome = client

--- a/crates/impetus-core/src/agent_loop.rs
+++ b/crates/impetus-core/src/agent_loop.rs
@@ -47,11 +47,11 @@ pub struct AgentLoop {
 }
 
 impl AgentLoop {
-    pub fn new(
-        runtime: Arc<AgentRuntime>,
-        policy: PolicyEngine,
-        workspace_root: std::path::PathBuf,
-    ) -> Self {
+    pub fn new(runtime: Arc<AgentRuntime>) -> Self {
+        let policy = runtime.policy();
+        let workspace_root = runtime
+            .workspace_root()
+            .expect("runtime always has a workspace root");
         Self {
             runtime,
             policy: policy.clone(),
@@ -97,6 +97,7 @@ impl AgentLoop {
 
             if tool_calls.is_empty() {
                 // No more tool calls — agent loop complete
+                self.runtime.record_agent_final(run_id, model_response)?;
                 return Ok(());
             }
 
@@ -109,15 +110,12 @@ impl AgentLoop {
             // Phase 4: Add observations to message history for next turn
             // Note: Using 'user' role for observations as assistant/tool_result
             // roles are not yet implemented in ProviderMessage
-            messages.push(ProviderMessage::user(format!(
-                "[Agent response]: {}",
-                model_response
-            )));
+            messages.push(ProviderMessage::assistant(model_response));
             for observation in observations {
-                messages.push(ProviderMessage::user(format!(
-                    "[Tool result]: {}",
-                    observation
-                )));
+                messages.push(ProviderMessage::tool(
+                    serde_json::to_string(&observation)
+                        .map_err(|error| ProviderError::RequestFailed(error.to_string()))?,
+                ));
             }
         }
     }
@@ -136,7 +134,21 @@ impl AgentLoop {
 
         let accumulated = Arc::new(std::sync::Mutex::new(String::new()));
         let runtime = self.runtime.clone();
-        let chunk_id = Arc::new(std::sync::Mutex::new(1u64));
+        let chunk_id = Arc::new(std::sync::Mutex::new(
+            self.runtime
+                .events()?
+                .iter()
+                .rev()
+                .find_map(|event| match &event.payload {
+                    crate::EventPayload::Agent(crate::AgentEvent::Chunk {
+                        run_id: event_run,
+                        chunk_id,
+                        ..
+                    }) if *event_run == run_id => Some(*chunk_id + 1),
+                    _ => None,
+                })
+                .unwrap_or(1),
+        ));
         let accumulated_clone = accumulated.clone();
 
         provider
@@ -242,6 +254,8 @@ pub struct ToolCall {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mock_provider::MockStreamItem;
+    use crate::{MemoryEventStore, MockProvider, SandboxScope};
 
     #[test]
     fn max_iterations_constant_is_reasonable() {
@@ -270,7 +284,7 @@ More text after.
         };
         let policy = PolicyEngine::new(scope);
         let runtime = Arc::new(AgentRuntime::new(store, policy.clone()));
-        let agent_loop = AgentLoop::new(runtime, policy, workspace);
+        let agent_loop = AgentLoop::new(runtime);
 
         let calls = agent_loop.extract_tool_calls(response);
         assert_eq!(calls.len(), 1);
@@ -301,7 +315,7 @@ More text after.
         };
         let policy = PolicyEngine::new(scope);
         let runtime = Arc::new(AgentRuntime::new(store, policy.clone()));
-        let agent_loop = AgentLoop::new(runtime, policy, workspace);
+        let agent_loop = AgentLoop::new(runtime);
 
         let calls = agent_loop.extract_tool_calls(response);
         assert_eq!(calls.len(), 2);
@@ -322,7 +336,7 @@ More text after.
         };
         let policy = PolicyEngine::new(scope);
         let runtime = Arc::new(AgentRuntime::new(store, policy.clone()));
-        let agent_loop = AgentLoop::new(runtime, policy, workspace);
+        let agent_loop = AgentLoop::new(runtime);
 
         let calls = agent_loop.extract_tool_calls(response);
         assert_eq!(calls.len(), 0);
@@ -350,7 +364,7 @@ More text after.
         };
         let policy = PolicyEngine::new(scope);
         let runtime = Arc::new(AgentRuntime::new(store, policy.clone()));
-        let agent_loop = AgentLoop::new(runtime, policy, workspace);
+        let agent_loop = AgentLoop::new(runtime);
 
         let calls = agent_loop.extract_tool_calls(response);
         assert_eq!(calls.len(), 1);
@@ -374,11 +388,66 @@ More text after.
         };
         let policy = PolicyEngine::new(scope);
         let runtime = Arc::new(AgentRuntime::new(store, policy.clone()));
-        let agent_loop = AgentLoop::new(runtime, policy, workspace);
+        let agent_loop = AgentLoop::new(runtime);
 
         let calls = agent_loop.extract_tool_calls(response);
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].name, "no_params_tool");
         assert_eq!(calls[0].arguments, serde_json::json!({}));
+    }
+
+    #[tokio::test]
+    async fn read_observation_is_returned_to_the_next_model_turn() {
+        let workspace = tempfile::tempdir().expect("temp workspace");
+        std::fs::write(workspace.path().join("evidence.txt"), "verified evidence")
+            .expect("write fixture");
+        let runtime = Arc::new(
+            AgentRuntime::create_with_workspace(
+                Arc::new(MemoryEventStore::default()),
+                PolicyEngine::new(SandboxScope::local_workspace(workspace.path())),
+                workspace.path().to_path_buf(),
+            )
+            .expect("runtime"),
+        );
+        let run_id = runtime
+            .submit_intent_and_start_run("read evidence")
+            .expect("start run");
+        let provider = Arc::new(MockProvider::scripted(
+            "scripted",
+            "test",
+            [
+                vec![MockStreamItem::Chunk {
+                    chunk_id: 1,
+                    text: "<tool_use><tool_name>read_file</tool_name><parameters>{\"path\":\"evidence.txt\"}</parameters></tool_use>".into(),
+                }],
+                vec![MockStreamItem::Chunk {
+                    chunk_id: 2,
+                    text: "final answer".into(),
+                }],
+            ],
+        ));
+        AgentLoop::new(runtime.clone())
+            .execute(
+                run_id,
+                provider.clone(),
+                vec![ProviderMessage::user("read evidence")],
+                CancellationToken::new(),
+            )
+            .await
+            .expect("agent loop");
+        let messages = provider.received_messages();
+        assert_eq!(messages.len(), 2);
+        let second_turn = serde_json::to_value(&messages[1]).expect("serialize messages");
+        assert!(second_turn.as_array().unwrap().iter().any(|message| {
+            message["role"] == "tool"
+                && message["content"]
+                    .as_str()
+                    .unwrap()
+                    .contains("verified evidence")
+        }));
+        assert!(runtime.events().unwrap().iter().any(|event| matches!(
+            &event.payload,
+            crate::EventPayload::Agent(crate::AgentEvent::Final { text, .. }) if text == "final answer"
+        )));
     }
 }

--- a/crates/impetus-core/src/effects.rs
+++ b/crates/impetus-core/src/effects.rs
@@ -152,6 +152,10 @@ pub struct DeferredEffect {
 }
 
 impl DeferredEffect {
+    pub fn from_durable(effect: NormalizedEffect, approval: ApprovalRequest) -> Self {
+        Self { effect, approval }
+    }
+
     pub fn approval(&self) -> &ApprovalRequest {
         &self.approval
     }
@@ -376,6 +380,21 @@ impl EffectSeam {
         current_intent_revision: u64,
         execution: impl FnOnce() -> Result<T, E>,
     ) -> Result<EffectExecution<T>, E> {
+        self.execute_after_approval_with_admission(
+            deferred,
+            resolution,
+            current_intent_revision,
+            |_| execution(),
+        )
+    }
+
+    pub fn execute_after_approval_with_admission<T, E>(
+        &self,
+        deferred: DeferredEffect,
+        resolution: ApprovalResolution,
+        current_intent_revision: u64,
+        execution: impl FnOnce(&AdmittedOperation) -> Result<T, E>,
+    ) -> Result<EffectExecution<T>, E> {
         let approval = deferred.approval;
 
         // Verify capability version matches
@@ -410,7 +429,11 @@ impl EffectSeam {
 
         Ok(match self.policy_decision(&deferred.effect.action) {
             PolicyDecision::NeedsApproval { .. } => match self.sandbox.admit(&deferred.effect) {
-                Ok(()) => EffectExecution::Executed(execution()?),
+                Ok(()) => {
+                    let admission =
+                        AdmittedOperation::new(deferred.effect.clone(), current_intent_revision);
+                    EffectExecution::Executed(execution(&admission)?)
+                }
                 Err(reason) => EffectExecution::Denied { reason },
             },
             PolicyDecision::Allow => EffectExecution::Denied {

--- a/crates/impetus-core/src/events.rs
+++ b/crates/impetus-core/src/events.rs
@@ -33,6 +33,7 @@ pub enum EventPayload {
 #[serde(rename_all = "snake_case")]
 pub enum SessionEvent {
     Created,
+    WorkspaceRoot { workspace_root: std::path::PathBuf },
     Attached,
 }
 
@@ -59,8 +60,37 @@ pub struct PlanEvent {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "state", rename_all = "snake_case")]
 pub enum ToolEvent {
-    Started { name: String },
-    Finished { name: String, summary: String },
+    Started {
+        name: String,
+    },
+    Finished {
+        name: String,
+        summary: String,
+    },
+    Observed {
+        tool_call_id: String,
+        tool_name: String,
+        arguments_summary: String,
+        outcome: ToolEventOutcome,
+        preview: String,
+        artifact: Option<crate::DurableArtifactRef>,
+        error: Option<String>,
+    },
+    Deferred {
+        approval_id: Uuid,
+        tool_call_id: String,
+        tool_name: String,
+        arguments: serde_json::Value,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolEventOutcome {
+    Success,
+    Error,
+    Denied,
+    ApprovalRequired,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/impetus-core/src/harness_api.rs
+++ b/crates/impetus-core/src/harness_api.rs
@@ -81,6 +81,31 @@ impl Harness {
         }
     }
 
+    #[cfg(test)]
+    fn with_test_provider(
+        store: Arc<dyn EventStore>,
+        policy: PolicyEngine,
+        provider: Arc<dyn crate::ModelProvider>,
+    ) -> Self {
+        let workspace_root = policy.scope().workspace_root.clone();
+        let default_provider_id = provider.provider_id().to_string();
+        let registry = ProviderRegistry::new();
+        registry
+            .register(provider)
+            .expect("failed to register test provider");
+        Self {
+            store,
+            policy,
+            provider_registry: registry,
+            default_provider_id,
+            credential_resolver: Arc::new(NoCredentialResolver),
+            cancellations: Arc::new(Mutex::new(HashMap::new())),
+            workspace_root,
+            session_coordinator: SessionCoordinator::default(),
+            attachments: crate::AttachmentStore::new(),
+        }
+    }
+
     /// Use a user-selected direct-provider profile. The profile is supplied by
     /// daemon startup, not client IPC; credentials remain outside this type.
     pub fn with_openai_provider(
@@ -408,46 +433,54 @@ fn handle_request(
                 accepted,
             };
             runtime.resolve_approval(resolution.clone())?;
-            if accepted && let Some(deferred) = deferred {
-                match deferred.1.as_str() {
-                    "write_file" | "edit_file" => crate::ToolOrchestrator::execute_approved_write(
-                        &runtime, request, resolution, deferred,
-                    ),
-                    "bash" | "shell" | "exec" => crate::ToolOrchestrator::execute_approved_bash(
-                        &runtime, request, resolution, deferred,
-                    ),
-                    name => Err(crate::OrchestratorError::ToolNotFound(name.into())),
-                }
-                .map_err(|error| RuntimeError::Denied(error.to_string()))?;
-                if let Some(run_id) = runtime.active_run_id()? {
-                    let workspace_root = runtime.workspace_root()?;
-                    let messages = resolve_provider_messages(&workspace_root, &runtime)
-                        .map_err(|error| RuntimeError::Denied(error.to_string()))?;
-                    let cancellation = CancellationToken::new();
-                    if let Ok(mut active) = cancellations.lock() {
-                        active.insert(session_id, cancellation.clone());
-                    }
-                    let task_runtime = runtime.clone();
-                    let task_registry = provider_registry.clone();
-                    let task_provider_id = default_provider_id.clone();
-                    let task_resolver = credential_resolver.clone();
-                    let task_cancellations = cancellations.clone();
-                    tokio::spawn(async move {
-                        run_agent_loop(
-                            task_runtime,
-                            run_id,
-                            task_registry,
-                            task_provider_id,
-                            task_resolver,
-                            messages,
-                            cancellation,
-                        )
-                        .await;
-                        if let Ok(mut active) = task_cancellations.lock() {
-                            active.remove(&session_id);
+            if let Some(deferred) = deferred {
+                if accepted {
+                    match deferred.1.as_str() {
+                        "write_file" | "edit_file" => {
+                            crate::ToolOrchestrator::execute_approved_write(
+                                &runtime, request, resolution, deferred,
+                            )
                         }
-                    });
+                        "bash" | "shell" | "exec" => {
+                            crate::ToolOrchestrator::execute_approved_bash(
+                                &runtime, request, resolution, deferred,
+                            )
+                        }
+                        name => Err(crate::OrchestratorError::ToolNotFound(name.into())),
+                    }
+                    .map_err(|error| RuntimeError::Denied(error.to_string()))?;
+                } else {
+                    crate::ToolOrchestrator::record_approval_rejection(&runtime, deferred);
                 }
+            }
+            if let Some(run_id) = runtime.active_run_id()? {
+                let workspace_root = runtime.workspace_root()?;
+                let messages = resolve_provider_messages(&workspace_root, &runtime)
+                    .map_err(|error| RuntimeError::Denied(error.to_string()))?;
+                let cancellation = CancellationToken::new();
+                if let Ok(mut active) = cancellations.lock() {
+                    active.insert(session_id, cancellation.clone());
+                }
+                let task_runtime = runtime.clone();
+                let task_registry = provider_registry.clone();
+                let task_provider_id = default_provider_id.clone();
+                let task_resolver = credential_resolver.clone();
+                let task_cancellations = cancellations.clone();
+                tokio::spawn(async move {
+                    run_agent_loop(
+                        task_runtime,
+                        run_id,
+                        task_registry,
+                        task_provider_id,
+                        task_resolver,
+                        messages,
+                        cancellation,
+                    )
+                    .await;
+                    if let Ok(mut active) = task_cancellations.lock() {
+                        active.remove(&session_id);
+                    }
+                });
             }
             Ok(session_id)
         }) {
@@ -838,7 +871,7 @@ mod tests {
     use super::*;
     use crate::{
         CredentialStrategy, EventPayload, MemoryEventStore, ProviderError, ProviderProfile,
-        RetryBudget,
+        RetryBudget, mock_provider::MockStreamItem,
     };
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
@@ -1314,5 +1347,198 @@ mod tests {
         assert!(detail.diff_preview.is_some());
         // New file creation case
         assert!(detail.diff_preview.unwrap().contains("new file"));
+    }
+
+    #[tokio::test]
+    async fn approval_resume_returns_durable_tool_observations_to_the_model() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("evidence.txt"), "confirmed evidence")
+            .expect("fixture");
+        let store = Arc::new(MemoryEventStore::default());
+        let provider = Arc::new(MockProvider::scripted(
+            "scripted",
+            "test-model",
+            [
+                vec![MockStreamItem::Chunk {
+                    chunk_id: 1,
+                    text: "<tool_use><tool_name>read_file</tool_name><parameters>{\"path\":\"evidence.txt\"}</parameters></tool_use>".into(),
+                }],
+                vec![MockStreamItem::Chunk {
+                    chunk_id: 1,
+                    text: "<tool_use><tool_name>write_file</tool_name><parameters>{\"path\":\"result.txt\",\"content\":\"approved result\"}</parameters></tool_use>".into(),
+                }],
+                vec![MockStreamItem::Chunk {
+                    chunk_id: 1,
+                    text: "completed after approval".into(),
+                }],
+            ],
+        ));
+        let harness = Harness::with_test_provider(
+            store.clone(),
+            PolicyEngine::new(SandboxScope::local_workspace(workspace.path())),
+            provider.clone(),
+        );
+        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession {
+            workspace_root: workspace.path().to_path_buf(),
+        }) else {
+            panic!("session creation")
+        };
+
+        assert!(matches!(
+            harness.handle(IpcRequest::Prompt {
+                session_id,
+                text: "inspect evidence and write the result".into(),
+            }),
+            IpcResponse::Status {
+                status: RuntimeStatus::Running,
+                ..
+            }
+        ));
+        for _ in 0..100 {
+            if matches!(
+                harness.handle(IpcRequest::Attach { session_id }),
+                IpcResponse::Session {
+                    status: RuntimeStatus::AwaitingApproval,
+                    ..
+                }
+            ) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        let IpcResponse::Events { events, .. } = harness.handle(IpcRequest::Stream {
+            session_id,
+            after_sequence: 0,
+        }) else {
+            panic!("event stream")
+        };
+        let approval_id = events
+            .iter()
+            .find_map(|event| match &event.payload {
+                EventPayload::Approval(crate::ApprovalEvent::Requested { request }) => {
+                    Some(request.id)
+                }
+                _ => None,
+            })
+            .expect("write approval");
+        assert!(matches!(
+            harness.handle(IpcRequest::ResolveApproval {
+                session_id,
+                approval_id,
+                accepted: true,
+            }),
+            IpcResponse::ApprovalResolved { .. }
+        ));
+        for _ in 0..100 {
+            if matches!(
+                harness.handle(IpcRequest::Attach { session_id }),
+                IpcResponse::Session {
+                    status: RuntimeStatus::Completed,
+                    ..
+                }
+            ) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        assert_eq!(
+            std::fs::read_to_string(workspace.path().join("result.txt")).expect("written result"),
+            "approved result"
+        );
+        let received = provider.received_messages();
+        assert_eq!(received.len(), 3);
+        let resume_context = serde_json::to_string(&received[2]).expect("serialize context");
+        assert!(resume_context.contains("confirmed evidence"));
+        assert!(resume_context.contains("file written"));
+        assert!(store.list(session_id).expect("events").iter().any(|event| {
+            matches!(
+                &event.payload,
+                EventPayload::Agent(crate::AgentEvent::Final { text, .. })
+                    if text == "completed after approval"
+            )
+        }));
+    }
+
+    #[tokio::test]
+    async fn rejected_approval_records_denial_and_resumes_without_execution() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let store = Arc::new(MemoryEventStore::default());
+        let provider = Arc::new(MockProvider::scripted(
+            "scripted-rejection",
+            "test-model",
+            [
+                vec![MockStreamItem::Chunk {
+                    chunk_id: 1,
+                    text: "<tool_use><tool_name>write_file</tool_name><parameters>{\"path\":\"blocked.txt\",\"content\":\"must not write\"}</parameters></tool_use>".into(),
+                }],
+                vec![MockStreamItem::Chunk {
+                    chunk_id: 1,
+                    text: "completed after rejection".into(),
+                }],
+            ],
+        ));
+        let harness = Harness::with_test_provider(
+            store.clone(),
+            PolicyEngine::new(SandboxScope::local_workspace(workspace.path())),
+            provider,
+        );
+        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession {
+            workspace_root: workspace.path().to_path_buf(),
+        }) else {
+            panic!("session creation")
+        };
+        harness.handle(IpcRequest::Prompt {
+            session_id,
+            text: "try the write".into(),
+        });
+        let approval_id = loop {
+            let IpcResponse::Events { events, .. } = harness.handle(IpcRequest::Stream {
+                session_id,
+                after_sequence: 0,
+            }) else {
+                panic!("event stream")
+            };
+            if let Some(approval_id) = events.iter().find_map(|event| match &event.payload {
+                EventPayload::Approval(crate::ApprovalEvent::Requested { request }) => {
+                    Some(request.id)
+                }
+                _ => None,
+            }) {
+                break approval_id;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        };
+        assert!(matches!(
+            harness.handle(IpcRequest::ResolveApproval {
+                session_id,
+                approval_id,
+                accepted: false,
+            }),
+            IpcResponse::ApprovalResolved { .. }
+        ));
+        for _ in 0..100 {
+            if matches!(
+                harness.handle(IpcRequest::Attach { session_id }),
+                IpcResponse::Session {
+                    status: RuntimeStatus::Completed,
+                    ..
+                }
+            ) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(!workspace.path().join("blocked.txt").exists());
+        assert!(store.list(session_id).expect("events").iter().any(|event| {
+            matches!(
+                &event.payload,
+                EventPayload::Tool(crate::ToolEvent::Observed {
+                    outcome: crate::ToolEventOutcome::Denied,
+                    error: Some(error),
+                    ..
+                }) if error == "user rejected approval"
+            )
+        }));
     }
 }

--- a/crates/impetus-core/src/harness_api.rs
+++ b/crates/impetus-core/src/harness_api.rs
@@ -8,11 +8,11 @@
 //! the client.
 
 use crate::{
-    AgentRuntime, CredentialResolver, DurableArtifactStore, EventStore, IPC_CAPABILITIES,
-    IPC_VERSION, InstructionResolver, IpcErrorCode, IpcRequest, IpcResponse, MockProvider,
-    NoCredentialResolver, OpenAiCompatibleAdapter, OpenAiCompatibleProvider, PolicyEngine,
-    ProviderError, ProviderMessage, ProviderRegistry, ReadOnlyTool, ReadOnlyToolKind,
-    ReadOnlyTools, ResolveRequest, RuntimeError, RuntimeStatus, Sandbox, SandboxScope, ToolOutcome,
+    AgentLoop, AgentRuntime, CredentialResolver, DurableArtifactStore, EventStore,
+    IPC_CAPABILITIES, IPC_VERSION, InstructionResolver, IpcErrorCode, IpcRequest, IpcResponse,
+    MockProvider, NoCredentialResolver, OpenAiCompatibleAdapter, OpenAiCompatibleProvider,
+    PolicyEngine, ProviderMessage, ProviderRegistry, ReadOnlyTool, ReadOnlyToolKind, ReadOnlyTools,
+    ResolveRequest, RuntimeError, RuntimeStatus, Sandbox, SandboxScope, ToolOutcome,
 };
 use anyhow::Result;
 use std::collections::HashMap;
@@ -212,13 +212,15 @@ fn handle_request(
                 .map(|capability| (*capability).to_owned())
                 .collect(),
         },
-        IpcRequest::CreateSession => match AgentRuntime::create(store, policy) {
-            Ok(runtime) => IpcResponse::Session {
-                session_id: runtime.session_id(),
-                status: RuntimeStatus::Idle,
-            },
-            Err(error) => runtime_error(error),
-        },
+        IpcRequest::CreateSession { workspace_root } => {
+            match AgentRuntime::create_with_workspace(store, policy, workspace_root) {
+                Ok(runtime) => IpcResponse::Session {
+                    session_id: runtime.session_id(),
+                    status: RuntimeStatus::Idle,
+                },
+                Err(error) => runtime_error(error),
+            }
+        }
         IpcRequest::Attach { session_id } => {
             match AgentRuntime::attach(store, policy, session_id)
                 .and_then(|runtime| Ok((runtime.session_id(), runtime.status()?)))
@@ -257,7 +259,8 @@ fn handle_request(
             match AgentRuntime::attach(store, policy, session_id).and_then(|runtime| {
                 let runtime = Arc::new(runtime);
                 let run_id = runtime.submit_intent_and_start_run(text)?;
-                let provider_messages = resolve_provider_messages(&workspace_root, &runtime)
+                let session_workspace = runtime.workspace_root()?;
+                let provider_messages = resolve_provider_messages(&session_workspace, &runtime)
                     .unwrap_or_else(|_| {
                         vec![ProviderMessage::user(
                             runtime_intent(&runtime).unwrap_or_default(),
@@ -274,7 +277,7 @@ fn handle_request(
                 let task_default_provider_id = default_provider_id.clone();
                 let task_credential_resolver = credential_resolver.clone();
                 tokio::spawn(async move {
-                    run_with_provider(
+                    run_agent_loop(
                         task_runtime,
                         run_id,
                         task_provider_registry,
@@ -296,7 +299,10 @@ fn handle_request(
         }
         IpcRequest::Context { session_id } => match AgentRuntime::attach(store, policy, session_id)
         {
-            Ok(_) => match resolve_context(&workspace_root) {
+            Ok(runtime) => match runtime.workspace_root().and_then(|workspace_root| {
+                resolve_context(&workspace_root)
+                    .map_err(|error| RuntimeError::Denied(error.to_string()))
+            }) {
                 Ok(context) => IpcResponse::Context {
                     session_id,
                     context,
@@ -335,16 +341,6 @@ fn handle_request(
         } => {
             let artifact_store = DurableArtifactStore::open(artifact_root().join("artifacts"))
                 .expect("open artifact store");
-            // The IPC effect scope is owned by the harness policy, not by the
-            // daemon's current directory or an independently constructed tool
-            // policy.  This keeps the fixed effect path coherent all the way
-            // to capability execution.
-            let workspace_root = policy.scope().workspace_root.clone();
-            let tools = ReadOnlyTools::new(&workspace_root);
-            let effect_seam = crate::EffectSeam::with_sandbox(
-                policy.clone(),
-                Sandbox::workspace(&workspace_root),
-            );
             let tool = match kind {
                 ReadOnlyToolKind::List => ReadOnlyTool::List {
                     target: target.into(),
@@ -364,6 +360,12 @@ fn handle_request(
             // origin is trusted.
             let origin = crate::ActionOrigin::User;
             match AgentRuntime::attach(store, policy, session_id).and_then(|runtime| {
+                let workspace_root = runtime.workspace_root()?;
+                let tools = ReadOnlyTools::new(&workspace_root);
+                let effect_seam = crate::EffectSeam::with_sandbox(
+                    runtime.policy(),
+                    Sandbox::workspace(&workspace_root),
+                );
                 tools
                     .run_with_seam(tool, origin, &artifact_store, &effect_seam)
                     .map_err(|e| RuntimeError::Denied(e.to_string()))
@@ -393,9 +395,11 @@ fn handle_request(
             approval_id,
             accepted,
         } => match AgentRuntime::attach(store, policy, session_id).and_then(|runtime| {
+            let runtime = Arc::new(runtime);
             let request = runtime
                 .pending_approval(approval_id)?
                 .ok_or(RuntimeError::MissingApproval(approval_id))?;
+            let deferred = runtime.deferred_tool(approval_id)?;
             let resolution = crate::ApprovalResolution {
                 id: approval_id,
                 resolver: crate::ApprovalResolver::User,
@@ -403,7 +407,48 @@ fn handle_request(
                 intent_revision: request.intent_revision,
                 accepted,
             };
-            runtime.resolve_approval(resolution)?;
+            runtime.resolve_approval(resolution.clone())?;
+            if accepted && let Some(deferred) = deferred {
+                match deferred.1.as_str() {
+                    "write_file" | "edit_file" => crate::ToolOrchestrator::execute_approved_write(
+                        &runtime, request, resolution, deferred,
+                    ),
+                    "bash" | "shell" | "exec" => crate::ToolOrchestrator::execute_approved_bash(
+                        &runtime, request, resolution, deferred,
+                    ),
+                    name => Err(crate::OrchestratorError::ToolNotFound(name.into())),
+                }
+                .map_err(|error| RuntimeError::Denied(error.to_string()))?;
+                if let Some(run_id) = runtime.active_run_id()? {
+                    let workspace_root = runtime.workspace_root()?;
+                    let messages = resolve_provider_messages(&workspace_root, &runtime)
+                        .map_err(|error| RuntimeError::Denied(error.to_string()))?;
+                    let cancellation = CancellationToken::new();
+                    if let Ok(mut active) = cancellations.lock() {
+                        active.insert(session_id, cancellation.clone());
+                    }
+                    let task_runtime = runtime.clone();
+                    let task_registry = provider_registry.clone();
+                    let task_provider_id = default_provider_id.clone();
+                    let task_resolver = credential_resolver.clone();
+                    let task_cancellations = cancellations.clone();
+                    tokio::spawn(async move {
+                        run_agent_loop(
+                            task_runtime,
+                            run_id,
+                            task_registry,
+                            task_provider_id,
+                            task_resolver,
+                            messages,
+                            cancellation,
+                        )
+                        .await;
+                        if let Ok(mut active) = task_cancellations.lock() {
+                            active.remove(&session_id);
+                        }
+                    });
+                }
+            }
             Ok(session_id)
         }) {
             Ok(session_id) => IpcResponse::ApprovalResolved {
@@ -459,7 +504,7 @@ fn handle_request(
     }
 }
 
-async fn run_with_provider(
+async fn run_agent_loop(
     runtime: Arc<AgentRuntime>,
     run_id: uuid::Uuid,
     provider_registry: ProviderRegistry,
@@ -480,55 +525,15 @@ async fn run_with_provider(
         Err(_) => return,
     };
 
-    let next_chunk_id = Arc::new(Mutex::new(
-        runtime
-            .events()
-            .ok()
-            .and_then(|events| {
-                events.iter().rev().find_map(|event| match &event.payload {
-                    crate::EventPayload::Agent(crate::AgentEvent::Chunk {
-                        run_id: event_run,
-                        chunk_id,
-                        ..
-                    }) if *event_run == run_id => Some(*chunk_id + 1),
-                    _ => None,
-                })
-            })
-            .unwrap_or(1),
-    ));
-
-    // TODO: credential resolution for OpenAI providers will be integrated
-    // when we add provider metadata and profile lookup to the registry.
-    // For now, credentials are resolved at provider registration time.
-    let credential = None;
-
-    let chunk_counter = next_chunk_id.clone();
-    let runtime_clone = runtime.clone();
-    let result = provider
-        .stream_messages(
-            &messages,
-            credential,
-            cancellation.clone(),
-            Box::new(move |chunk| {
-                let chunk_id = {
-                    let mut counter = chunk_counter.lock().unwrap();
-                    let id = *counter;
-                    *counter += 1;
-                    id
-                };
-                runtime_clone
-                    .record_agent_chunk(run_id, chunk_id, chunk)
-                    .map(|_| ())
-                    .map_err(|error| ProviderError::RequestFailed(error.to_string()))
-            }),
-        )
+    let result = AgentLoop::new(runtime.clone())
+        .execute(run_id, provider, messages, cancellation.clone())
         .await;
 
     match result {
         Ok(()) if matches!(runtime.status(), Ok(RuntimeStatus::Running)) => {
             let _ = runtime.finish_run(crate::RunEvent::Completed { run_id });
         }
-        Err(ProviderError::Cancelled) => {}
+        Err(_) if cancellation.is_cancelled() => {}
         Err(error) if matches!(runtime.status(), Ok(RuntimeStatus::Running)) => {
             let _ = runtime.finish_run(crate::RunEvent::Failed {
                 run_id,
@@ -556,7 +561,57 @@ fn resolve_provider_messages(
         .into_iter()
         .map(|reference| ProviderMessage::system(reference.text))
         .collect::<Vec<_>>();
-    messages.push(ProviderMessage::user(runtime_intent(runtime)?));
+    let mut pending_assistant = String::new();
+    let mut has_user_intent = false;
+    for event in runtime.events()? {
+        match event.payload {
+            crate::EventPayload::Intent(intent) => {
+                if !pending_assistant.is_empty() {
+                    messages.push(ProviderMessage::assistant(std::mem::take(
+                        &mut pending_assistant,
+                    )));
+                }
+                messages.push(ProviderMessage::user(intent.text));
+                has_user_intent = true;
+            }
+            crate::EventPayload::Agent(crate::AgentEvent::Chunk { text, .. }) => {
+                pending_assistant.push_str(&text);
+            }
+            crate::EventPayload::Tool(crate::ToolEvent::Observed {
+                tool_call_id,
+                tool_name,
+                arguments_summary,
+                outcome,
+                preview,
+                artifact,
+                error,
+            }) => {
+                if !pending_assistant.is_empty() {
+                    messages.push(ProviderMessage::assistant(std::mem::take(
+                        &mut pending_assistant,
+                    )));
+                }
+                messages.push(ProviderMessage::tool(serde_json::to_string(
+                    &serde_json::json!({
+                        "tool_call_id": tool_call_id,
+                        "tool_name": tool_name,
+                        "arguments_summary": arguments_summary,
+                        "outcome": outcome,
+                        "preview": preview,
+                        "artifact": artifact,
+                        "error": error,
+                    }),
+                )?));
+            }
+            _ => {}
+        }
+    }
+    if !pending_assistant.is_empty() {
+        messages.push(ProviderMessage::assistant(pending_assistant));
+    }
+    if !has_user_intent {
+        messages.push(ProviderMessage::user(runtime_intent(runtime)?));
+    }
     Ok(messages)
 }
 
@@ -781,9 +836,68 @@ fn compute_approval_detail(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CredentialStrategy, EventPayload, MemoryEventStore, ProviderProfile, RetryBudget};
+    use crate::{
+        CredentialStrategy, EventPayload, MemoryEventStore, ProviderError, ProviderProfile,
+        RetryBudget,
+    };
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+
+    #[test]
+    fn sessions_keep_distinct_workspaces_after_attach() {
+        let root = tempfile::tempdir().expect("temp root");
+        let workspace_a = root.path().join("a");
+        let workspace_b = root.path().join("b");
+        std::fs::create_dir(&workspace_a).expect("create workspace a");
+        std::fs::create_dir(&workspace_b).expect("create workspace b");
+        std::fs::write(workspace_b.join("only-b.txt"), "b").expect("write fixture");
+        let harness = Harness::new(
+            Arc::new(MemoryEventStore::default()),
+            PolicyEngine::new(SandboxScope::local_workspace(root.path())),
+        );
+        let IpcResponse::Session {
+            session_id: session_a,
+            ..
+        } = harness.handle(IpcRequest::CreateSession {
+            workspace_root: workspace_a,
+        })
+        else {
+            panic!("create session a")
+        };
+        let IpcResponse::Session {
+            session_id: session_b,
+            ..
+        } = harness.handle(IpcRequest::CreateSession {
+            workspace_root: workspace_b,
+        })
+        else {
+            panic!("create session b")
+        };
+        assert!(matches!(
+            harness.handle(IpcRequest::Tool {
+                session_id: session_a,
+                kind: ReadOnlyToolKind::Read,
+                target: "only-b.txt".into(),
+                pattern: None,
+            }),
+            IpcResponse::ToolResult {
+                outcome: ToolOutcome::Denied { .. },
+                ..
+            }
+        ));
+        assert!(matches!(
+            harness.handle(IpcRequest::Tool {
+                session_id: session_b,
+                kind: ReadOnlyToolKind::Read,
+                target: "only-b.txt".into(),
+                pattern: None,
+            }),
+            IpcResponse::ToolResult {
+                outcome: ToolOutcome::Allowed { .. },
+                ..
+            }
+        ));
+    }
 
     #[tokio::test]
     async fn explicit_local_profile_streams_durable_chunks_through_harness() {
@@ -816,8 +930,12 @@ mod tests {
             policy(),
             provider,
         );
-        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession)
-        else {
+        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession {
+            workspace_root: std::env::current_dir()
+                .expect("workspace")
+                .canonicalize()
+                .expect("canonical workspace"),
+        }) else {
             panic!("session creation response")
         };
         assert!(matches!(
@@ -863,6 +981,12 @@ mod tests {
                 .collect::<String>(),
             "evidence answer"
         );
+        assert!(events.iter().any(|event| {
+            matches!(
+                &event.payload,
+                EventPayload::Agent(crate::AgentEvent::Final { text, .. }) if text == "evidence answer"
+            )
+        }));
         server.await.unwrap();
     }
 
@@ -876,8 +1000,9 @@ mod tests {
             Arc::new(MemoryEventStore::default()),
             PolicyEngine::new(SandboxScope::local_workspace(&root)),
         );
-        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession)
-        else {
+        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession {
+            workspace_root: root.clone(),
+        }) else {
             panic!("session creation response");
         };
 
@@ -916,8 +1041,9 @@ mod tests {
         let expected_decision = policy.evaluate(&denied_ssh);
         let store = Arc::new(MemoryEventStore::default());
         let harness = Harness::new(store.clone(), policy.clone());
-        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession)
-        else {
+        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession {
+            workspace_root: root.clone(),
+        }) else {
             panic!("session creation response");
         };
 
@@ -984,8 +1110,12 @@ mod tests {
             Arc::new(resolver),
         );
         assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0);
-        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession)
-        else {
+        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession {
+            workspace_root: std::env::current_dir()
+                .expect("workspace")
+                .canonicalize()
+                .expect("canonical workspace"),
+        }) else {
             panic!("session creation response")
         };
         assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0);
@@ -1031,8 +1161,12 @@ mod tests {
         let policy = PolicyEngine::new(SandboxScope::local_workspace("."));
         let harness = Harness::new(store.clone(), policy.clone());
 
-        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession)
-        else {
+        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession {
+            workspace_root: std::env::current_dir()
+                .expect("workspace")
+                .canonicalize()
+                .expect("canonical workspace"),
+        }) else {
             panic!("session creation response");
         };
 
@@ -1118,8 +1252,12 @@ mod tests {
         let policy = PolicyEngine::new(SandboxScope::local_workspace("."));
         let harness = Harness::new(store.clone(), policy.clone());
 
-        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession)
-        else {
+        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession {
+            workspace_root: std::env::current_dir()
+                .expect("workspace")
+                .canonicalize()
+                .expect("canonical workspace"),
+        }) else {
             panic!("session creation response");
         };
 

--- a/crates/impetus-core/src/ipc.rs
+++ b/crates/impetus-core/src/ipc.rs
@@ -2,7 +2,7 @@ use crate::RuntimeStatus;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-pub const IPC_VERSION: u16 = 2;
+pub const IPC_VERSION: u16 = 3;
 pub const IPC_CAPABILITIES: &[&str] = &[
     "session_create",
     "session_attach",
@@ -26,7 +26,9 @@ pub enum IpcRequest {
         version: u16,
         capabilities: Vec<String>,
     },
-    CreateSession,
+    CreateSession {
+        workspace_root: std::path::PathBuf,
+    },
     Attach {
         session_id: Uuid,
     },

--- a/crates/impetus-core/src/lib.rs
+++ b/crates/impetus-core/src/lib.rs
@@ -65,6 +65,7 @@ pub use effects::{
 pub use events::{
     AgentEvent, ApprovalEvent, BackendEvent, BudgetEvent, EVENT_SCHEMA_VERSION, Event,
     EventPayload, IntentEvent, NoticeEvent, PlanEvent, RunEvent, SessionEvent, ToolEvent,
+    ToolEventOutcome,
 };
 pub use execution::{
     ProcessExecution, ProcessExecutionError, ProcessExecutionRequest, ProcessOutput, PtySession,

--- a/crates/impetus-core/src/mock_provider.rs
+++ b/crates/impetus-core/src/mock_provider.rs
@@ -4,6 +4,8 @@
 
 use crate::{ModelProvider, ProviderError, ProviderHealth, ProviderMessage};
 use async_trait::async_trait;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
 use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18,6 +20,8 @@ pub struct MockProvider {
     provider_id: String,
     model_id: String,
     items: Vec<MockStreamItem>,
+    scripts: Arc<Mutex<VecDeque<Vec<MockStreamItem>>>>,
+    received_messages: Arc<Mutex<Vec<Vec<ProviderMessage>>>>,
 }
 
 impl MockProvider {
@@ -30,7 +34,26 @@ impl MockProvider {
             provider_id: provider_id.into(),
             model_id: model_id.into(),
             items: items.into_iter().collect(),
+            scripts: Arc::new(Mutex::new(VecDeque::new())),
+            received_messages: Arc::new(Mutex::new(Vec::new())),
         }
+    }
+
+    pub fn scripted(
+        provider_id: impl Into<String>,
+        model_id: impl Into<String>,
+        scripts: impl IntoIterator<Item = Vec<MockStreamItem>>,
+    ) -> Self {
+        let mut provider = Self::new(provider_id, model_id, []);
+        provider.scripts = Arc::new(Mutex::new(scripts.into_iter().collect()));
+        provider
+    }
+
+    pub fn received_messages(&self) -> Vec<Vec<ProviderMessage>> {
+        self.received_messages
+            .lock()
+            .map(|messages| messages.clone())
+            .unwrap_or_default()
     }
 
     pub fn default_mock() -> Self {
@@ -67,12 +90,21 @@ impl ModelProvider for MockProvider {
 
     async fn stream_messages(
         &self,
-        _messages: &[ProviderMessage],
+        messages: &[ProviderMessage],
         _credential: Option<&str>,
         cancel: CancellationToken,
         mut on_chunk: Box<dyn FnMut(String) -> Result<(), ProviderError> + Send>,
     ) -> Result<(), ProviderError> {
-        for item in &self.items {
+        if let Ok(mut received) = self.received_messages.lock() {
+            received.push(messages.to_vec());
+        }
+        let items = self
+            .scripts
+            .lock()
+            .ok()
+            .and_then(|mut scripts| scripts.pop_front())
+            .unwrap_or_else(|| self.items.clone());
+        for item in &items {
             if cancel.is_cancelled() {
                 return Err(ProviderError::Cancelled);
             }

--- a/crates/impetus-core/src/projection.rs
+++ b/crates/impetus-core/src/projection.rs
@@ -3,6 +3,7 @@ use crate::{
     IntentEvent, PlanEvent, RunEvent, ToolEvent,
 };
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -13,10 +14,12 @@ pub struct SessionProjection {
     pub latest_intent: Option<String>,
     pub latest_intent_revision: Option<u64>,
     pub latest_plan: Option<String>,
+    pub workspace_root: Option<PathBuf>,
     pub tool_summaries: BTreeMap<String, String>,
     pub agent_output: String,
     pub agent_chunk_ids: BTreeMap<Uuid, u64>,
     pub pending_approvals: BTreeMap<Uuid, ApprovalRequest>,
+    pub deferred_tools: BTreeMap<Uuid, (String, String, serde_json::Value)>,
     pub active_run_id: Option<Uuid>,
     pub last_run_id: Option<Uuid>,
     pub outcome: Option<RunEvent>,
@@ -42,10 +45,12 @@ pub fn reduce(events: &[Event]) -> Result<Option<SessionProjection>, ProjectionE
         latest_intent: None,
         latest_intent_revision: None,
         latest_plan: None,
+        workspace_root: None,
         tool_summaries: BTreeMap::new(),
         agent_output: String::new(),
         agent_chunk_ids: BTreeMap::new(),
         pending_approvals: BTreeMap::new(),
+        deferred_tools: BTreeMap::new(),
         active_run_id: None,
         last_run_id: None,
         outcome: None,
@@ -72,6 +77,9 @@ pub fn reduce(events: &[Event]) -> Result<Option<SessionProjection>, ProjectionE
         }
         projection.last_sequence = event.sequence;
         match &event.payload {
+            EventPayload::Session(crate::SessionEvent::WorkspaceRoot { workspace_root }) => {
+                projection.workspace_root = Some(workspace_root.clone());
+            }
             EventPayload::Intent(IntentEvent { text }) => {
                 projection.latest_intent = Some(text.clone());
                 projection.latest_intent_revision = Some(event.sequence);
@@ -88,6 +96,24 @@ pub fn reduce(events: &[Event]) -> Result<Option<SessionProjection>, ProjectionE
                 projection
                     .tool_summaries
                     .insert(name.clone(), summary.clone());
+            }
+            EventPayload::Tool(ToolEvent::Observed {
+                tool_name, outcome, ..
+            }) => {
+                projection
+                    .tool_summaries
+                    .insert(tool_name.clone(), format!("{outcome:?}"));
+            }
+            EventPayload::Tool(ToolEvent::Deferred {
+                approval_id,
+                tool_call_id,
+                tool_name,
+                arguments,
+            }) => {
+                projection.deferred_tools.insert(
+                    *approval_id,
+                    (tool_call_id.clone(), tool_name.clone(), arguments.clone()),
+                );
             }
             EventPayload::Agent(AgentEvent::Chunk {
                 run_id,
@@ -110,6 +136,7 @@ pub fn reduce(events: &[Event]) -> Result<Option<SessionProjection>, ProjectionE
             }
             EventPayload::Approval(ApprovalEvent::Resolved { request }) => {
                 projection.pending_approvals.remove(&request.id);
+                projection.deferred_tools.remove(&request.id);
             }
             EventPayload::Run(RunEvent::Started { run_id }) => {
                 projection.active_run_id = Some(*run_id);

--- a/crates/impetus-core/src/provider.rs
+++ b/crates/impetus-core/src/provider.rs
@@ -63,6 +63,20 @@ impl ProviderMessage {
             content: content.into(),
         }
     }
+
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: "assistant",
+            content: content.into(),
+        }
+    }
+
+    pub fn tool(content: impl Into<String>) -> Self {
+        Self {
+            role: "tool",
+            content: content.into(),
+        }
+    }
 }
 
 /// Resolves an explicit profile's credential only when a provider request is

--- a/crates/impetus-core/src/runtime.rs
+++ b/crates/impetus-core/src/runtime.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
 use uuid::Uuid;
@@ -45,15 +46,24 @@ pub enum RuntimeError {
     InactiveRun(Uuid),
     #[error("run `{0}` is already active")]
     ActiveRun(Uuid),
+    #[error("workspace root `{0}` is not a directory")]
+    InvalidWorkspace(PathBuf),
 }
 
 pub struct AgentRuntime {
     session_id: Uuid,
     store: Arc<dyn EventStore>,
     policy: PolicyEngine,
+    workspace_root: PathBuf,
     // A2 Phase 2: Store deferred effects for approval continuation.
     // Maps approval_id -> DeferredEffect so approved work can resume.
     deferred_effects: Arc<Mutex<HashMap<Uuid, DeferredEffect>>>,
+}
+
+fn policy_for_workspace(policy: &PolicyEngine, workspace_root: PathBuf) -> PolicyEngine {
+    let mut scope = policy.scope().clone();
+    scope.workspace_root = workspace_root;
+    PolicyEngine::new(scope)
 }
 
 impl AgentRuntime {
@@ -65,7 +75,36 @@ impl AgentRuntime {
         Ok(Self {
             session_id: store.create_session()?,
             store,
+            workspace_root: policy.scope().workspace_root.clone(),
             policy,
+            deferred_effects: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    pub fn create_with_workspace(
+        store: Arc<dyn EventStore>,
+        policy: PolicyEngine,
+        workspace_root: PathBuf,
+    ) -> Result<Self, RuntimeError> {
+        let workspace_root = workspace_root
+            .canonicalize()
+            .map_err(|_| RuntimeError::InvalidWorkspace(workspace_root.clone()))?;
+        if !workspace_root.is_dir() {
+            return Err(RuntimeError::InvalidWorkspace(workspace_root));
+        }
+        let session_id = store.create_session()?;
+        let scoped_policy = policy_for_workspace(&policy, workspace_root.clone());
+        store.append_next(
+            session_id,
+            EventPayload::Session(crate::SessionEvent::WorkspaceRoot {
+                workspace_root: workspace_root.clone(),
+            }),
+        )?;
+        Ok(Self {
+            session_id,
+            store,
+            policy: scoped_policy,
+            workspace_root,
             deferred_effects: Arc::new(Mutex::new(HashMap::new())),
         })
     }
@@ -79,11 +118,15 @@ impl AgentRuntime {
         if events.is_empty() {
             return Err(RuntimeError::MissingSession(session_id));
         }
-        reduce(&events)?;
+        let projection = reduce(&events)?.ok_or(RuntimeError::MissingSession(session_id))?;
+        let workspace_root = projection
+            .workspace_root
+            .unwrap_or_else(|| policy.scope().workspace_root.clone());
         Ok(Self {
             session_id,
             store,
-            policy,
+            policy: policy_for_workspace(&policy, workspace_root.clone()),
+            workspace_root,
             deferred_effects: Arc::new(Mutex::new(HashMap::new())),
         })
     }
@@ -98,6 +141,7 @@ impl AgentRuntime {
         Ok(Self {
             session_id: new_session_id,
             store,
+            workspace_root: policy.scope().workspace_root.clone(),
             policy,
             deferred_effects: Arc::new(Mutex::new(HashMap::new())),
         })
@@ -105,6 +149,14 @@ impl AgentRuntime {
 
     pub fn session_id(&self) -> Uuid {
         self.session_id
+    }
+
+    pub fn workspace_root(&self) -> Result<PathBuf, RuntimeError> {
+        Ok(self.workspace_root.clone())
+    }
+
+    pub fn policy(&self) -> PolicyEngine {
+        self.policy.clone()
     }
 
     pub fn submit_intent(&self, text: impl Into<String>) -> Result<(), RuntimeError> {
@@ -172,7 +224,29 @@ impl AgentRuntime {
         Ok(true)
     }
 
+    pub fn record_agent_final(
+        &self,
+        run_id: Uuid,
+        text: impl Into<String>,
+    ) -> Result<(), RuntimeError> {
+        if self.projection()?.active_run_id != Some(run_id) {
+            return Err(RuntimeError::InactiveRun(run_id));
+        }
+        self.record(EventPayload::Agent(crate::AgentEvent::Final {
+            run_id,
+            text: text.into(),
+        }))
+    }
+
     pub fn request_action(&self, action: Action) -> Result<RuntimeStatus, RuntimeError> {
+        self.request_action_with_capability_version(action, None)
+    }
+
+    pub fn request_action_with_capability_version(
+        &self,
+        action: Action,
+        capability_version: Option<u32>,
+    ) -> Result<RuntimeStatus, RuntimeError> {
         match self.policy.evaluate(&action) {
             PolicyDecision::Allow => {
                 self.record(EventPayload::Notice(NoticeEvent::PolicyAllowed))?;
@@ -189,7 +263,12 @@ impl AgentRuntime {
                     .projection()?
                     .latest_intent_revision
                     .ok_or(RuntimeError::MissingIntentRevision)?;
-                let approval = crate::ApprovalRequest::pending(action, reason, intent_revision);
+                let approval = crate::ApprovalRequest::pending_with_version(
+                    action,
+                    reason,
+                    intent_revision,
+                    capability_version,
+                );
                 self.record(EventPayload::Approval(ApprovalEvent::Requested {
                     request: approval,
                 }))?;
@@ -299,6 +378,32 @@ impl AgentRuntime {
         Ok(self.projection()?.pending_approvals.get(&id).cloned())
     }
 
+    pub fn active_run_id(&self) -> Result<Option<Uuid>, RuntimeError> {
+        Ok(self.projection()?.active_run_id)
+    }
+
+    pub fn record_deferred_tool(
+        &self,
+        approval_id: Uuid,
+        tool_call_id: String,
+        tool_name: String,
+        arguments: serde_json::Value,
+    ) -> Result<(), RuntimeError> {
+        self.record(EventPayload::Tool(ToolEvent::Deferred {
+            approval_id,
+            tool_call_id,
+            tool_name,
+            arguments,
+        }))
+    }
+
+    pub fn deferred_tool(
+        &self,
+        approval_id: Uuid,
+    ) -> Result<Option<(String, String, serde_json::Value)>, RuntimeError> {
+        Ok(self.projection()?.deferred_tools.get(&approval_id).cloned())
+    }
+
     pub fn cancel(&self) -> Result<RuntimeStatus, RuntimeError> {
         let projection = self.projection()?;
         let Some(run_id) = projection.active_run_id else {
@@ -356,6 +461,37 @@ mod tests {
                     event.payload,
                     EventPayload::Approval(ApprovalEvent::Requested { .. })
                 ))
+        );
+    }
+
+    #[test]
+    fn session_workspace_is_canonical_and_survives_attach() {
+        let root = tempfile::tempdir().expect("temp root");
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        let store = Arc::new(MemoryEventStore::default());
+        let runtime = AgentRuntime::create_with_workspace(
+            store.clone(),
+            PolicyEngine::new(SandboxScope::local_workspace(root.path())),
+            workspace.clone(),
+        )
+        .expect("create runtime");
+        let session_id = runtime.session_id();
+        let canonical_workspace = workspace.canonicalize().expect("canonical workspace");
+        assert_eq!(
+            runtime.workspace_root().expect("workspace root"),
+            canonical_workspace
+        );
+
+        let attached = AgentRuntime::attach(
+            store,
+            PolicyEngine::new(SandboxScope::local_workspace(root.path())),
+            session_id,
+        )
+        .expect("attach runtime");
+        assert_eq!(
+            attached.workspace_root().expect("attached workspace root"),
+            canonical_workspace
         );
     }
 

--- a/crates/impetus-core/src/tool_orchestrator.rs
+++ b/crates/impetus-core/src/tool_orchestrator.rs
@@ -302,6 +302,26 @@ impl ToolOrchestrator {
         }
     }
 
+    pub fn record_approval_rejection(
+        runtime: &Arc<AgentRuntime>,
+        deferred: (String, String, serde_json::Value),
+    ) -> ToolObservation {
+        let (tool_call_id, tool_name, arguments) = deferred;
+        Self::record_observation(
+            runtime,
+            crate::ToolCall {
+                id: tool_call_id,
+                name: tool_name,
+                arguments: arguments.clone(),
+            },
+            summarize_arguments(&arguments),
+            ToolOutcomeStatus::Denied,
+            String::new(),
+            None,
+            Some("user rejected approval".into()),
+        )
+    }
+
     pub fn execute_approved_write(
         runtime: &Arc<AgentRuntime>,
         request: crate::ApprovalRequest,

--- a/crates/impetus-core/src/tool_orchestrator.rs
+++ b/crates/impetus-core/src/tool_orchestrator.rs
@@ -8,7 +8,8 @@
 //! - Tool execution coordination
 
 use crate::{
-    Action, ActionKind, ActionOrigin, AgentRuntime, PolicyDecision, PolicyEngine, RuntimeError,
+    Action, ActionKind, ActionOrigin, AgentRuntime, DurableArtifactStore, EffectSeam, PolicyEngine,
+    ReadOnlyTool, ReadOnlyTools, RuntimeError, Sandbox, ToolEvent, ToolEventOutcome, ToolOutcome,
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -43,18 +44,14 @@ pub struct ToolRequest {
 pub struct ToolObservation {
     pub tool_call_id: String,
     pub tool_name: String,
+    pub arguments_summary: String,
     pub outcome: ToolOutcomeStatus,
-    pub content: String,
+    pub preview: String,
+    pub artifact: Option<crate::DurableArtifactRef>,
+    pub error: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ToolOutcomeStatus {
-    Success,
-    Error,
-    Denied,
-    ApprovalRequired,
-}
+pub type ToolOutcomeStatus = ToolEventOutcome;
 
 /// Tool Orchestrator coordinates tool execution through the safety boundary.
 #[allow(dead_code)] // Fields used in future iterations
@@ -85,7 +82,7 @@ impl ToolOrchestrator {
         _run_id: Uuid,
         tool_calls: Vec<crate::ToolCall>,
         runtime: &Arc<AgentRuntime>,
-    ) -> Result<Vec<String>, OrchestratorError> {
+    ) -> Result<Vec<ToolObservation>, OrchestratorError> {
         let mut observations = Vec::new();
 
         for tool_call in tool_calls {
@@ -100,45 +97,100 @@ impl ToolOrchestrator {
         &self,
         tool_call: crate::ToolCall,
         runtime: &Arc<AgentRuntime>,
-    ) -> String {
+    ) -> ToolObservation {
+        let arguments_summary = summarize_arguments(&tool_call.arguments);
         // Step 1: Normalize tool call into Action
         let action = match self.normalize_tool_call(&tool_call) {
             Ok(action) => action,
             Err(e) => {
-                return format!("Tool '{}' failed to normalize: {}", tool_call.name, e);
+                return Self::record_observation(
+                    runtime,
+                    tool_call,
+                    arguments_summary,
+                    ToolOutcomeStatus::Error,
+                    String::new(),
+                    None,
+                    Some(e.to_string()),
+                );
             }
         };
 
-        // Step 2: Policy decision
-        let decision = self.policy.evaluate(&action);
+        if matches!(
+            action.kind,
+            ActionKind::WriteFile | ActionKind::SpawnProcess
+        ) {
+            if contains_sensitive_value(&tool_call.arguments) {
+                return Self::record_observation(
+                    runtime,
+                    tool_call,
+                    arguments_summary,
+                    ToolOutcomeStatus::Denied,
+                    String::new(),
+                    None,
+                    Some("mutating tool arguments contain sensitive material".into()),
+                );
+            }
+            let outcome = match runtime.request_action_with_capability_version(action, Some(1)) {
+                Ok(_) => {
+                    if let Some(approval_id) = runtime.events().ok().and_then(|events| {
+                        events.iter().rev().find_map(|event| match &event.payload {
+                            crate::EventPayload::Approval(crate::ApprovalEvent::Requested {
+                                request,
+                            }) => Some(request.id),
+                            _ => None,
+                        })
+                    }) {
+                        let _ = runtime.record_deferred_tool(
+                            approval_id,
+                            tool_call.id.clone(),
+                            tool_call.name.clone(),
+                            tool_call.arguments.clone(),
+                        );
+                    }
+                    ToolOutcomeStatus::ApprovalRequired
+                }
+                Err(RuntimeError::Denied(_)) => ToolOutcomeStatus::Denied,
+                Err(_) => ToolOutcomeStatus::Error,
+            };
+            return Self::record_observation(
+                runtime,
+                tool_call,
+                arguments_summary,
+                outcome,
+                String::new(),
+                None,
+                Some("awaiting user approval".into()),
+            );
+        }
 
-        match decision {
-            PolicyDecision::Allow => {
-                // Step 3: Execute tool
-                match self.execute_tool(&tool_call).await {
-                    Ok(outcome) => format!("Tool '{}' result: {}", tool_call.name, outcome),
-                    Err(e) => format!("Tool '{}' failed: {}", tool_call.name, e),
-                }
-            }
-            PolicyDecision::Deny { reason } => {
-                // Record denial
-                let _ =
-                    runtime.record_event(crate::EventPayload::Tool(crate::ToolEvent::Finished {
-                        name: tool_call.name.clone(),
-                        summary: format!("denied: {}", reason),
-                    }));
-                format!("Tool '{}' denied: {}", tool_call.name, reason)
-            }
-            PolicyDecision::NeedsApproval { reason } => {
-                // Step 4: Request approval (deferred execution)
-                match runtime.request_action(action.clone()) {
-                    Ok(_) => format!(
-                        "Tool '{}' requires approval: {}. Execution paused.",
-                        tool_call.name, reason
-                    ),
-                    Err(e) => format!("Tool '{}' approval request failed: {}", tool_call.name, e),
-                }
-            }
+        match self.execute_read_only(&tool_call) {
+            Ok(ToolOutcome::Allowed { result }) => Self::record_observation(
+                runtime,
+                tool_call,
+                arguments_summary,
+                ToolOutcomeStatus::Success,
+                result.preview,
+                result.artifact,
+                None,
+            ),
+            Ok(ToolOutcome::Denied { reason, .. }) => Self::record_observation(
+                runtime,
+                tool_call,
+                arguments_summary,
+                ToolOutcomeStatus::Denied,
+                String::new(),
+                None,
+                Some(reason),
+            ),
+            Err(error) => Self::record_observation(
+                runtime,
+                tool_call,
+                arguments_summary,
+                ToolOutcomeStatus::Error,
+                String::new(),
+                None,
+                Some(error.to_string()),
+            ),
         }
     }
 
@@ -148,7 +200,7 @@ impl ToolOrchestrator {
     ) -> Result<Action, OrchestratorError> {
         // Map tool names to ActionKind
         let kind = match tool_call.name.as_str() {
-            "read_file" => ActionKind::ReadFile,
+            "list_files" | "read_file" | "search" => ActionKind::ReadFile,
             "write_file" | "edit_file" => ActionKind::WriteFile,
             "bash" | "shell" | "exec" => ActionKind::SpawnProcess,
             name => {
@@ -162,6 +214,11 @@ impl ToolOrchestrator {
             .or_else(|| tool_call.arguments.get("command"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        let target = if kind == ActionKind::SpawnProcess {
+            Some(self.workspace_root.display().to_string())
+        } else {
+            target
+        };
 
         Ok(Action {
             origin: ActionOrigin::Agent,
@@ -171,14 +228,270 @@ impl ToolOrchestrator {
         })
     }
 
-    async fn execute_tool(&self, tool_call: &crate::ToolCall) -> Result<String, OrchestratorError> {
-        // TODO: Integrate with existing ReadOnlyTools and effects system
-        // For now, return placeholder
-        Ok(format!(
-            "Tool '{}' executed successfully (placeholder)",
-            tool_call.name
+    fn execute_read_only(
+        &self,
+        tool_call: &crate::ToolCall,
+    ) -> Result<ToolOutcome, OrchestratorError> {
+        let target = tool_call
+            .arguments
+            .get("path")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or(".");
+        let tool = match tool_call.name.as_str() {
+            "list_files" => ReadOnlyTool::List {
+                target: target.into(),
+            },
+            "read_file" => ReadOnlyTool::Read {
+                target: target.into(),
+            },
+            "search" => ReadOnlyTool::Search {
+                target: target.into(),
+                pattern: tool_call
+                    .arguments
+                    .get("pattern")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .into(),
+            },
+            name => return Err(OrchestratorError::ToolNotFound(name.into())),
+        };
+        let artifacts =
+            DurableArtifactStore::open(std::env::temp_dir().join("impetus-agent-artifacts"))
+                .map_err(|error| OrchestratorError::ToolFailed {
+                    tool: tool_call.name.clone(),
+                    reason: error.to_string(),
+                })?;
+        let seam = EffectSeam::with_sandbox(
+            self.policy.clone(),
+            Sandbox::workspace(&self.workspace_root),
+        );
+        ReadOnlyTools::new(&self.workspace_root)
+            .run_with_seam(tool, ActionOrigin::Agent, &artifacts, &seam)
+            .map_err(|error| OrchestratorError::ToolFailed {
+                tool: tool_call.name.clone(),
+                reason: error.to_string(),
+            })
+    }
+
+    fn record_observation(
+        runtime: &Arc<AgentRuntime>,
+        tool_call: crate::ToolCall,
+        arguments_summary: String,
+        outcome: ToolOutcomeStatus,
+        preview: String,
+        artifact: Option<crate::DurableArtifactRef>,
+        error: Option<String>,
+    ) -> ToolObservation {
+        let _ = runtime.record_event(crate::EventPayload::Tool(ToolEvent::Observed {
+            tool_call_id: tool_call.id.clone(),
+            tool_name: tool_call.name.clone(),
+            arguments_summary: arguments_summary.clone(),
+            outcome: outcome.clone(),
+            preview: preview.clone(),
+            artifact: artifact.clone(),
+            error: error.clone(),
+        }));
+        ToolObservation {
+            tool_call_id: tool_call.id,
+            tool_name: tool_call.name,
+            arguments_summary,
+            outcome,
+            preview,
+            artifact,
+            error,
+        }
+    }
+
+    pub fn execute_approved_write(
+        runtime: &Arc<AgentRuntime>,
+        request: crate::ApprovalRequest,
+        resolution: crate::ApprovalResolution,
+        deferred: (String, String, serde_json::Value),
+    ) -> Result<ToolObservation, OrchestratorError> {
+        let (tool_call_id, tool_name, arguments) = deferred;
+        if !matches!(tool_name.as_str(), "write_file" | "edit_file") {
+            return Err(OrchestratorError::ToolNotFound(tool_name));
+        }
+        let path = arguments
+            .get("path")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| OrchestratorError::ToolFailed {
+                tool: tool_name.clone(),
+                reason: "write tool requires path".into(),
+            })?;
+        let content = arguments
+            .get("content")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| OrchestratorError::ToolFailed {
+                tool: tool_name.clone(),
+                reason: "write tool requires content".into(),
+            })?;
+        let effect = crate::NormalizedEffect::workspace_write(
+            ActionOrigin::Agent,
+            format!("{tool_name} via agent"),
+            path,
+        );
+        if effect.action != request.action {
+            return Err(OrchestratorError::Denied(
+                "deferred action no longer matches approval".into(),
+            ));
+        }
+        let workspace = runtime.workspace_root()?;
+        let seam = EffectSeam::with_sandbox(runtime.policy(), Sandbox::workspace(&workspace));
+        let execution = seam
+            .execute_after_approval(
+                crate::DeferredEffect::from_durable(effect, request.clone()),
+                resolution,
+                request.intent_revision,
+                || {
+                    crate::tools::write_file_in_scope(
+                        &workspace,
+                        PathBuf::from(path).as_path(),
+                        content,
+                    )
+                },
+            )
+            .map_err(|error| OrchestratorError::ToolFailed {
+                tool: tool_name.clone(),
+                reason: error.to_string(),
+            })?;
+        let (outcome, preview, error) = match execution {
+            crate::EffectExecution::Executed(()) => {
+                (ToolOutcomeStatus::Success, "file written".into(), None)
+            }
+            crate::EffectExecution::Denied { reason } => {
+                (ToolOutcomeStatus::Denied, String::new(), Some(reason))
+            }
+            crate::EffectExecution::NeedsApproval { reason } => (
+                ToolOutcomeStatus::ApprovalRequired,
+                String::new(),
+                Some(reason),
+            ),
+        };
+        Ok(Self::record_observation(
+            runtime,
+            crate::ToolCall {
+                id: tool_call_id,
+                name: tool_name,
+                arguments: arguments.clone(),
+            },
+            summarize_arguments(&arguments),
+            outcome,
+            preview,
+            None,
+            error,
         ))
     }
+
+    pub fn execute_approved_bash(
+        runtime: &Arc<AgentRuntime>,
+        request: crate::ApprovalRequest,
+        resolution: crate::ApprovalResolution,
+        deferred: (String, String, serde_json::Value),
+    ) -> Result<ToolObservation, OrchestratorError> {
+        let (tool_call_id, tool_name, arguments) = deferred;
+        if !matches!(tool_name.as_str(), "bash" | "shell" | "exec") {
+            return Err(OrchestratorError::ToolNotFound(tool_name));
+        }
+        let command = arguments
+            .get("command")
+            .and_then(serde_json::Value::as_str)
+            .filter(|command| !command.trim().is_empty())
+            .ok_or_else(|| OrchestratorError::ToolFailed {
+                tool: tool_name.clone(),
+                reason: "shell tool requires command".into(),
+            })?;
+        let workspace = runtime.workspace_root()?;
+        let effect = crate::NormalizedEffect::process_spawn(
+            ActionOrigin::Agent,
+            format!("{tool_name} via agent"),
+            workspace.display().to_string(),
+        );
+        if effect.action != request.action {
+            return Err(OrchestratorError::Denied(
+                "deferred action no longer matches approval".into(),
+            ));
+        }
+        let process = crate::ProcessExecutionRequest::new(
+            "/bin/sh",
+            vec!["-lc".into(), command.into()],
+            ActionOrigin::Agent,
+            request.intent_revision,
+        )
+        .with_working_dir(workspace.clone());
+        let seam = EffectSeam::with_sandbox(runtime.policy(), Sandbox::workspace(&workspace));
+        let execution = seam
+            .execute_after_approval_with_admission(
+                crate::DeferredEffect::from_durable(effect, request.clone()),
+                resolution,
+                request.intent_revision,
+                |admission| {
+                    std::thread::scope(|scope| {
+                        scope
+                            .spawn(|| {
+                                tokio::runtime::Builder::new_current_thread()
+                                    .enable_all()
+                                    .build()
+                                    .map_err(crate::ProcessExecutionError::Io)?
+                                    .block_on(process.execute(admission))
+                            })
+                            .join()
+                            .map_err(|_| {
+                                crate::ProcessExecutionError::ExecutionFailed(
+                                    "process worker panicked".into(),
+                                )
+                            })
+                    })?
+                },
+            )
+            .map_err(|error| OrchestratorError::ToolFailed {
+                tool: tool_name.clone(),
+                reason: error.to_string(),
+            })?;
+        let (outcome, preview, error) = match execution {
+            crate::EffectExecution::Executed(output) => (
+                ToolOutcomeStatus::Success,
+                crate::tools::redact_text(&format!(
+                    "exit_code={:?}\nstdout:\n{}\nstderr:\n{}",
+                    output.exit_code, output.stdout, output.stderr
+                )),
+                None,
+            ),
+            crate::EffectExecution::Denied { reason } => {
+                (ToolOutcomeStatus::Denied, String::new(), Some(reason))
+            }
+            crate::EffectExecution::NeedsApproval { reason } => (
+                ToolOutcomeStatus::ApprovalRequired,
+                String::new(),
+                Some(reason),
+            ),
+        };
+        Ok(Self::record_observation(
+            runtime,
+            crate::ToolCall {
+                id: tool_call_id,
+                name: tool_name,
+                arguments: arguments.clone(),
+            },
+            summarize_arguments(&arguments),
+            outcome,
+            preview,
+            None,
+            error,
+        ))
+    }
+}
+
+fn summarize_arguments(arguments: &serde_json::Value) -> String {
+    crate::tools::redact_text(&serde_json::to_string(arguments).unwrap_or_default())
+        .chars()
+        .take(1024)
+        .collect()
+}
+
+fn contains_sensitive_value(arguments: &serde_json::Value) -> bool {
+    let raw = serde_json::to_string(arguments).unwrap_or_default();
+    crate::tools::redact_text(&raw) != raw
 }
 
 #[cfg(test)]
@@ -219,15 +532,21 @@ mod tests {
 
     #[tokio::test]
     async fn process_tool_calls_returns_observations() {
+        let workspace = tempfile::tempdir().expect("temp workspace");
+        std::fs::write(
+            workspace.path().join("evidence.txt"),
+            "secret=hidden\nproof",
+        )
+        .expect("write fixture");
         let store = Arc::new(MemoryEventStore::default());
-        let policy = PolicyEngine::new(SandboxScope::local_workspace("."));
+        let policy = PolicyEngine::new(SandboxScope::local_workspace(workspace.path()));
         let runtime = Arc::new(AgentRuntime::new(store, policy.clone()));
-        let orchestrator = ToolOrchestrator::new(policy, PathBuf::from("."));
+        let orchestrator = ToolOrchestrator::new(policy, workspace.path().to_path_buf());
 
         let tool_calls = vec![crate::ToolCall {
             id: "call_1".to_string(),
             name: "read_file".to_string(),
-            arguments: serde_json::json!({"path": "test.txt"}),
+            arguments: serde_json::json!({"path": "evidence.txt"}),
         }];
 
         let observations = orchestrator
@@ -236,6 +555,126 @@ mod tests {
             .unwrap();
 
         assert_eq!(observations.len(), 1);
-        assert!(observations[0].contains("read_file"));
+        assert_eq!(observations[0].outcome, ToolOutcomeStatus::Success);
+        assert!(observations[0].preview.contains("[REDACTED]"));
+        assert!(runtime.events().unwrap().iter().any(|event| {
+            matches!(
+                &event.payload,
+                crate::EventPayload::Tool(crate::ToolEvent::Observed {
+                    tool_call_id,
+                    outcome: ToolOutcomeStatus::Success,
+                    ..
+                }) if tool_call_id == "call_1"
+            )
+        }));
+    }
+
+    #[tokio::test]
+    async fn write_is_durable_deferred_until_approval() {
+        let workspace = tempfile::tempdir().expect("temp workspace");
+        let store = Arc::new(MemoryEventStore::default());
+        let policy = PolicyEngine::new(SandboxScope::local_workspace(workspace.path()));
+        let runtime = Arc::new(AgentRuntime::new(store, policy.clone()));
+        runtime.submit_intent("write a note").expect("intent");
+        let orchestrator = ToolOrchestrator::new(policy, workspace.path().to_path_buf());
+        let observations = orchestrator
+            .process_tool_calls(
+                Uuid::new_v4(),
+                vec![crate::ToolCall {
+                    id: "write-1".into(),
+                    name: "write_file".into(),
+                    arguments: serde_json::json!({"path": "note.txt", "content": "approved"}),
+                }],
+                &runtime,
+            )
+            .await
+            .expect("tool call");
+        assert_eq!(observations[0].outcome, ToolOutcomeStatus::ApprovalRequired);
+        assert!(!workspace.path().join("note.txt").exists());
+        assert!(runtime.events().unwrap().iter().any(|event| {
+            matches!(
+                &event.payload,
+                crate::EventPayload::Tool(crate::ToolEvent::Deferred {
+                    tool_call_id,
+                    tool_name,
+                    ..
+                }) if tool_call_id == "write-1" && tool_name == "write_file"
+            )
+        }));
+        let request = runtime
+            .events()
+            .unwrap()
+            .iter()
+            .find_map(|event| match &event.payload {
+                crate::EventPayload::Approval(crate::ApprovalEvent::Requested { request }) => {
+                    Some(request.clone())
+                }
+                _ => None,
+            })
+            .expect("approval request");
+        let deferred = runtime
+            .deferred_tool(request.id)
+            .expect("deferred lookup")
+            .expect("deferred tool");
+        let resolution = crate::ApprovalResolution::user(&request, true);
+        runtime
+            .resolve_approval(resolution.clone())
+            .expect("resolve approval");
+        let observation =
+            ToolOrchestrator::execute_approved_write(&runtime, request, resolution, deferred)
+                .expect("execute approved write");
+        assert_eq!(observation.outcome, ToolOutcomeStatus::Success);
+        assert_eq!(
+            std::fs::read_to_string(workspace.path().join("note.txt")).expect("written file"),
+            "approved"
+        );
+    }
+
+    #[tokio::test]
+    async fn bash_executes_only_after_exact_user_approval() {
+        let workspace = tempfile::tempdir().expect("temp workspace");
+        let runtime = Arc::new(AgentRuntime::new(
+            Arc::new(MemoryEventStore::default()),
+            PolicyEngine::new(SandboxScope::local_workspace(workspace.path())),
+        ));
+        runtime.submit_intent("inspect workspace").expect("intent");
+        let orchestrator = ToolOrchestrator::new(runtime.policy(), workspace.path().to_path_buf());
+        let observations = orchestrator
+            .process_tool_calls(
+                Uuid::new_v4(),
+                vec![crate::ToolCall {
+                    id: "bash-1".into(),
+                    name: "bash".into(),
+                    arguments: serde_json::json!({"command": "printf verified"}),
+                }],
+                &runtime,
+            )
+            .await
+            .expect("request bash");
+        assert_eq!(observations[0].outcome, ToolOutcomeStatus::ApprovalRequired);
+        let request = runtime
+            .events()
+            .unwrap()
+            .iter()
+            .find_map(|event| match &event.payload {
+                crate::EventPayload::Approval(crate::ApprovalEvent::Requested { request }) => {
+                    Some(request.clone())
+                }
+                _ => None,
+            })
+            .expect("approval request");
+        let deferred = runtime
+            .deferred_tool(request.id)
+            .expect("deferred lookup")
+            .expect("deferred bash");
+        let resolution = crate::ApprovalResolution::user(&request, true);
+        runtime
+            .resolve_approval(resolution.clone())
+            .expect("approval");
+        let observation =
+            ToolOrchestrator::execute_approved_bash(&runtime, request, resolution, deferred)
+                .expect("approved shell execution");
+        assert_eq!(observation.outcome, ToolOutcomeStatus::Success);
+        assert!(observation.preview.contains("verified"));
     }
 }

--- a/crates/impetus-core/src/tools.rs
+++ b/crates/impetus-core/src/tools.rs
@@ -51,6 +51,32 @@ impl ReadOnlyTool {
     }
 }
 
+pub(crate) fn write_file_in_scope(
+    workspace_root: &Path,
+    target: &Path,
+    content: &str,
+) -> Result<(), ToolError> {
+    let root = workspace_root
+        .canonicalize()
+        .map_err(|error| ToolError::Io(error.to_string()))?;
+    let target = if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        root.join(target)
+    };
+    let parent = target
+        .parent()
+        .ok_or_else(|| ToolError::Io("write target has no parent".into()))?
+        .canonicalize()
+        .map_err(|error| ToolError::Io(error.to_string()))?;
+    if !parent.starts_with(&root) {
+        return Err(ToolError::Io(
+            "write target is outside workspace scope".into(),
+        ));
+    }
+    std::fs::write(target, content).map_err(|error| ToolError::Io(error.to_string()))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolProvenance {
     pub workspace_root: PathBuf,

--- a/crates/impetus-core/tests/resource_baseline.rs
+++ b/crates/impetus-core/tests/resource_baseline.rs
@@ -80,9 +80,18 @@ fn baseline_artifact_bytes() {
     let id_large = artifacts.store(&large).expect("store large");
 
     // Проверяем размер через metadata
-    let meta_small = artifacts.metadata(&id_small.id).expect("metadata small").expect("artifact not found");
-    let meta_medium = artifacts.metadata(&id_medium.id).expect("metadata medium").expect("artifact not found");
-    let meta_large = artifacts.metadata(&id_large.id).expect("metadata large").expect("artifact not found");
+    let meta_small = artifacts
+        .metadata(&id_small.id)
+        .expect("metadata small")
+        .expect("artifact not found");
+    let meta_medium = artifacts
+        .metadata(&id_medium.id)
+        .expect("metadata medium")
+        .expect("artifact not found");
+    let meta_large = artifacts
+        .metadata(&id_large.id)
+        .expect("metadata large")
+        .expect("artifact not found");
 
     assert_eq!(meta_small.byte_count, small.len());
     assert_eq!(meta_medium.byte_count, medium.len());

--- a/crates/impetus-zap-adapter/src/main.rs
+++ b/crates/impetus-zap-adapter/src/main.rs
@@ -111,8 +111,9 @@ async fn create_and_attach(
     prompt: &str,
     status_bar: StatusBar,
 ) -> Result<()> {
+    let workspace_root = std::env::current_dir()?.canonicalize()?;
     let response = transport
-        .request(IpcRequest::CreateSession)
+        .request(IpcRequest::CreateSession { workspace_root })
         .await
         .context("Failed to create session")?;
 

--- a/crates/impetus-zap-adapter/src/status_bar.rs
+++ b/crates/impetus-zap-adapter/src/status_bar.rs
@@ -70,6 +70,12 @@ impl StatusBar {
                     ToolEvent::Finished { .. } => {
                         state.current_action = None;
                     }
+                    ToolEvent::Observed { tool_name, .. } => {
+                        state.current_action = Some(format!("Tool: {tool_name}"));
+                    }
+                    ToolEvent::Deferred { tool_name, .. } => {
+                        state.current_action = Some(format!("Approval required: {tool_name}"));
+                    }
                 }
             }
             EventPayload::Approval(approval_event) => {

--- a/crates/impetus/src/main.rs
+++ b/crates/impetus/src/main.rs
@@ -35,6 +35,16 @@ enum Commands {
         /// Session ID to cancel
         session_id: Uuid,
     },
+    /// Approve or reject a pending agent action
+    Approve {
+        /// Session that owns the approval
+        session_id: Uuid,
+        /// Pending approval ID
+        approval_id: Uuid,
+        /// Reject the pending action instead of approving it
+        #[arg(long)]
+        reject: bool,
+    },
     /// Send a prompt to a session
     Prompt {
         /// Session ID to prompt
@@ -121,6 +131,28 @@ async fn main() -> Result<()> {
                 other => bail!("Unexpected response: {other:?}"),
             }
         }
+        Commands::Approve {
+            session_id,
+            approval_id,
+            reject,
+        } => {
+            let response = client
+                .request(impetus_core::IpcRequest::ResolveApproval {
+                    session_id,
+                    approval_id,
+                    accepted: !reject,
+                })
+                .await?;
+            match response {
+                impetus_core::IpcResponse::ApprovalResolved { .. } => {
+                    println!("Approval {approval_id} resolved for session {session_id}");
+                }
+                impetus_core::IpcResponse::Error { message, .. } => {
+                    bail!("Error resolving approval: {message}");
+                }
+                other => bail!("Unexpected response: {other:?}"),
+            }
+        }
         Commands::Prompt { session_id, text } => {
             let response = client
                 .request(impetus_core::IpcRequest::Prompt { session_id, text })
@@ -181,5 +213,23 @@ mod tests {
         let id = Uuid::new_v4();
         let cli = Cli::try_parse_from(["impetus", "context", &id.to_string()]).unwrap();
         assert!(matches!(cli.command, Commands::Context { session_id } if session_id == id));
+    }
+
+    #[test]
+    fn parses_rejected_approval() {
+        let session_id = Uuid::new_v4();
+        let approval_id = Uuid::new_v4();
+        let cli = Cli::try_parse_from([
+            "impetus",
+            "approve",
+            &session_id.to_string(),
+            &approval_id.to_string(),
+            "--reject",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Approve { reject: true, .. }
+        ));
     }
 }

--- a/crates/impetus/src/main.rs
+++ b/crates/impetus/src/main.rs
@@ -72,8 +72,9 @@ async fn main() -> Result<()> {
     match cli.command {
         Commands::Doctor { .. } => unreachable!("handled above"),
         Commands::Create => {
+            let workspace_root = std::env::current_dir()?.canonicalize()?;
             let response = client
-                .request(impetus_core::IpcRequest::CreateSession)
+                .request(impetus_core::IpcRequest::CreateSession { workspace_root })
                 .await?;
             match response {
                 impetus_core::IpcResponse::Session { session_id, status } => {

--- a/crates/impetusd/src/main.rs
+++ b/crates/impetusd/src/main.rs
@@ -220,7 +220,7 @@ async fn write_response(
 fn required_capability(request: &IpcRequest) -> &'static str {
     match request {
         IpcRequest::Hello { .. } => unreachable!("hello is negotiated separately"),
-        IpcRequest::CreateSession => "session_create",
+        IpcRequest::CreateSession { .. } => "session_create",
         IpcRequest::Attach { .. } => "session_attach",
         IpcRequest::ListSessions => "session_list",
         IpcRequest::Stream { .. } => "event_stream",
@@ -333,9 +333,12 @@ mod tests {
     #[tokio::test]
     async fn prompt_restarts_mock_provider_without_duplicating_durable_chunks() {
         let store = Arc::new(MemoryEventStore::default());
-        let IpcResponse::Session { session_id, .. } =
-            handle_request(store.clone(), IpcRequest::CreateSession)
-        else {
+        let IpcResponse::Session { session_id, .. } = handle_request(
+            store.clone(),
+            IpcRequest::CreateSession {
+                workspace_root: std::env::current_dir().unwrap().canonicalize().unwrap(),
+            },
+        ) else {
             panic!("create session response")
         };
         assert!(matches!(
@@ -400,9 +403,12 @@ mod tests {
     #[tokio::test]
     async fn tool_read_outside_workspace_is_denied_over_ipc() {
         let store = Arc::new(MemoryEventStore::default());
-        let IpcResponse::Session { session_id, .. } =
-            handle_request(store.clone(), IpcRequest::CreateSession)
-        else {
+        let IpcResponse::Session { session_id, .. } = handle_request(
+            store.clone(),
+            IpcRequest::CreateSession {
+                workspace_root: std::env::current_dir().unwrap().canonicalize().unwrap(),
+            },
+        ) else {
             panic!("create session response")
         };
         // Workspace root for the harness test is the crate directory; an
@@ -429,9 +435,12 @@ mod tests {
     #[tokio::test]
     async fn cancel_stops_mock_stream_before_restart_completes_it() {
         let store = Arc::new(MemoryEventStore::default());
-        let IpcResponse::Session { session_id, .. } =
-            handle_request(store.clone(), IpcRequest::CreateSession)
-        else {
+        let IpcResponse::Session { session_id, .. } = handle_request(
+            store.clone(),
+            IpcRequest::CreateSession {
+                workspace_root: std::env::current_dir().unwrap().canonicalize().unwrap(),
+            },
+        ) else {
             panic!("create session response")
         };
         assert!(matches!(
@@ -478,8 +487,9 @@ mod tests {
     async fn second_prompt_is_rejected_while_run_is_active() {
         let store = Arc::new(MemoryEventStore::default());
         let harness = Harness::new(store.clone(), impetus_core::harness_api::policy());
-        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession)
-        else {
+        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession {
+            workspace_root: std::env::current_dir().unwrap().canonicalize().unwrap(),
+        }) else {
             panic!("create session response")
         };
         assert!(matches!(

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,18 +1,18 @@
 # Roadmap
 
-Canonical product path. Инварианты — [ARCHITECTURE.md](../ARCHITECTURE.md);
-исполнимые задачи — [TODO.md](../TODO.md).
+Canonical product path. Invariants are in [ARCHITECTURE.md](../ARCHITECTURE.md);
+executable tasks are in [TODO.md](../TODO.md).
 
 ## FOUNDATION — current
 
-- Durable events и SQLite WAL.
-- Crate split `impetus` (client) / `impetusd` (daemon) / `impetus-core` (in progress; docs/tooling cleanup pending).
+- Durable events and SQLite WAL.
+- Crate split `impetus` (client) / `impetusd` (daemon) / `impetus-core`.
 - Versioned local IPC, `HarnessClient`.
 - Safety, capability, sandbox, approval, secret-reference base.
 - `ModelProvider` и `ProviderRegistry` foundations.
 - Basic copied-event fork и compaction/budget primitives.
 - Attachment/diff/detail DTOs with bounded **ephemeral/in-memory** backing (not durable `ArtifactStore`).
-- Agent Loop / Tool Orchestrator **skeleton** — `extract_tool_calls()` and tool execution still placeholder.
+- Agent Loop / Tool Orchestrator vertical slice: read tools execute through policy and sandbox; writes and shell commands require exact user approval, then resume with durable observations.
 
 ## MODULE RUNTIME / EXTENSIBILITY FOUNDATION
 
@@ -51,7 +51,10 @@ Canonical product path. Инварианты — [ARCHITECTURE.md](../ARCHITECTU
 
 ### Agent Loop
 
-**Current:** skeleton types and wiring; `extract_tool_calls()` and real tool execution are placeholders.
+**Current:** a working single-session vertical slice parses model tool calls,
+executes read-only tools, defers mutating tools for exact approval, and resumes
+the model from durable observations. Native provider tool-call protocols, web
+research, durable artifact backing, and model routing remain future work.
 
 **Target:**
 
@@ -64,8 +67,12 @@ Model → Tool Orchestrator → Tool request → Effect normalization
 
 ### Tool Orchestrator
 
-**Target:** structured tool lifecycle, normalized effects, durable observations,
-explicit safety admission.
+**Current:** structured tool lifecycle, normalized effects, durable observations,
+and explicit safety admission for `list_files`, `read_file`, `search`,
+`write_file`, `edit_file`, and `bash`/`shell`/`exec`.
+
+**Target:** provider-native structured tool calls, durable artifact backing,
+bounded execution, and the remaining tool families.
 
 ### Model Router
 


### PR DESCRIPTION
## Summary
- route agent turns through durable workspace-aware sessions
- execute read tools and approved write/bash actions through policy and sandbox seams
- resume model turns with durable observations after approval or rejection
- add CLI approval controls and E2E coverage

Refs #23

## Verification
- task verify
- task ci:list