### PR TITLE
fix: harden durable agent observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Zap keeps its own UI as another `HarnessClient` consumer. See
   experimental Zap integration baseline.
 - Agent-loop vertical for filesystem reads plus approval-gated writes and shell
   commands; each result is persisted before it is returned to the model.
+- Large read results use content-addressed durable artifacts; events retain a
+  bounded, redacted preview and an artifact reference.
 
 ## Request control flow
 

--- a/TODO.md
+++ b/TODO.md
@@ -207,6 +207,7 @@ The baseline vertical is working. The remaining items harden and extend it.
 - [x] Replace `extract_tool_calls()` placeholder with provider-aware parsing
 - [x] Wire Tool Orchestrator to real tool execution through policy/sandbox path
 - [x] Durable observations from executed tools (not stub responses)
+- [x] Large read output uses durable content-addressed artifacts and bounded event previews
 - [x] End-to-end slice: model → tool request → execution → observation → model
 - [ ] Wire web research tools through `WebResearchService` (when WEB slice lands)
 

--- a/crates/impetus-core/src/durable_artifacts.rs
+++ b/crates/impetus-core/src/durable_artifacts.rs
@@ -16,6 +16,19 @@ pub struct DurableArtifactStore {
     conn: Arc<Mutex<Connection>>,
 }
 
+/// Stable local storage for tool artifacts. The location can be overridden for
+/// tests and portable installations without moving event data into a workspace.
+pub fn default_artifact_root() -> PathBuf {
+    std::env::var_os("IMPETUS_DATA_DIR")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .map(|home| PathBuf::from(home).join("Library/Application Support/Impetus"))
+        })
+        .unwrap_or_else(|| PathBuf::from("artifacts"))
+        .join("artifacts")
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ArtifactRef {
     pub id: String,

--- a/crates/impetus-core/src/harness_api.rs
+++ b/crates/impetus-core/src/harness_api.rs
@@ -364,7 +364,7 @@ fn handle_request(
             target,
             pattern,
         } => {
-            let artifact_store = DurableArtifactStore::open(artifact_root().join("artifacts"))
+            let artifact_store = DurableArtifactStore::open(crate::default_artifact_root())
                 .expect("open artifact store");
             let tool = match kind {
                 ReadOnlyToolKind::List => ReadOnlyTool::List {
@@ -517,7 +517,8 @@ fn handle_request(
                 let request = runtime
                     .pending_approval(approval_id)?
                     .ok_or(RuntimeError::MissingApproval(approval_id))?;
-                let detail = compute_approval_detail(request, &workspace_root, &attachments)?;
+                let session_workspace = runtime.workspace_root()?;
+                let detail = compute_approval_detail(request, &session_workspace, &attachments)?;
                 Ok((session_id, detail))
             },
         ) {
@@ -746,21 +747,6 @@ fn gather_subsystem_health(
 
 pub fn policy() -> PolicyEngine {
     PolicyEngine::new(SandboxScope::local_workspace("."))
-}
-
-fn data_root() -> Result<PathBuf> {
-    Ok(std::env::var_os("IMPETUS_DATA_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            PathBuf::from(std::env::var_os("HOME").expect("HOME is set on macOS"))
-                .join("Library/Application Support/Impetus")
-        }))
-}
-
-fn artifact_root() -> PathBuf {
-    data_root()
-        .map(|root| root.join("artifacts"))
-        .unwrap_or_else(|_| PathBuf::from("artifacts"))
 }
 
 /// Compute detailed approval information with diff preview and scope estimates.
@@ -1349,6 +1335,60 @@ mod tests {
         assert!(detail.diff_preview.unwrap().contains("new file"));
     }
 
+    #[test]
+    fn approval_detail_uses_the_session_workspace() {
+        let root = tempfile::tempdir().expect("root");
+        let daemon_workspace = root.path().join("daemon");
+        let session_workspace = root.path().join("session");
+        std::fs::create_dir(&daemon_workspace).expect("daemon workspace");
+        std::fs::create_dir(&session_workspace).expect("session workspace");
+        std::fs::write(session_workspace.join("existing.txt"), "session content")
+            .expect("session fixture");
+        let policy = PolicyEngine::new(SandboxScope::local_workspace(&daemon_workspace));
+        let harness = Harness::new(Arc::new(MemoryEventStore::default()), policy.clone());
+        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession {
+            workspace_root: session_workspace,
+        }) else {
+            panic!("session creation")
+        };
+        let runtime = AgentRuntime::attach(harness.store(), policy, session_id).expect("attach");
+        runtime.submit_intent("edit session file").expect("intent");
+        runtime
+            .request_action(crate::Action {
+                origin: crate::ActionOrigin::Agent,
+                kind: crate::ActionKind::WriteFile,
+                summary: "edit existing file".into(),
+                target: Some("existing.txt".into()),
+            })
+            .expect("approval request");
+        let approval_id = runtime
+            .events()
+            .expect("events")
+            .into_iter()
+            .find_map(|event| match event.payload {
+                EventPayload::Approval(crate::ApprovalEvent::Requested { request }) => {
+                    Some(request.id)
+                }
+                _ => None,
+            })
+            .expect("approval id");
+
+        let IpcResponse::ApprovalDetail { detail, .. } =
+            harness.handle(IpcRequest::GetApprovalDetail {
+                session_id,
+                approval_id,
+            })
+        else {
+            panic!("approval detail")
+        };
+        assert!(
+            detail
+                .diff_preview
+                .expect("existing file diff")
+                .contains("session content")
+        );
+    }
+
     #[tokio::test]
     async fn approval_resume_returns_durable_tool_observations_to_the_model() {
         let workspace = tempfile::tempdir().expect("workspace");
@@ -1538,6 +1578,63 @@ mod tests {
                     error: Some(error),
                     ..
                 }) if error == "user rejected approval"
+            )
+        }));
+    }
+
+    #[tokio::test]
+    async fn cancellation_stops_an_active_agent_run_without_a_final_answer() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let provider = Arc::new(MockProvider::scripted(
+            "slow-scripted",
+            "test-model",
+            [vec![MockStreamItem::Chunk {
+                chunk_id: 1,
+                text: "still running ".repeat(200),
+            }]],
+        ));
+        let harness = Harness::with_test_provider(
+            Arc::new(MemoryEventStore::default()),
+            PolicyEngine::new(SandboxScope::local_workspace(workspace.path())),
+            provider,
+        );
+        let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession {
+            workspace_root: workspace.path().to_path_buf(),
+        }) else {
+            panic!("session creation")
+        };
+        assert!(matches!(
+            harness.handle(IpcRequest::Prompt {
+                session_id,
+                text: "start a long task".into(),
+            }),
+            IpcResponse::Status {
+                status: RuntimeStatus::Running,
+                ..
+            }
+        ));
+        assert!(matches!(
+            harness.handle(IpcRequest::Cancel { session_id }),
+            IpcResponse::Status {
+                status: RuntimeStatus::Cancelled,
+                ..
+            }
+        ));
+        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+        let IpcResponse::Events { events, .. } = harness.handle(IpcRequest::Stream {
+            session_id,
+            after_sequence: 0,
+        }) else {
+            panic!("event stream")
+        };
+        assert!(matches!(
+            events.last().map(|event| &event.payload),
+            Some(EventPayload::Run(crate::RunEvent::Cancelled { .. }))
+        ));
+        assert!(!events.iter().any(|event| {
+            matches!(
+                event.payload,
+                EventPayload::Agent(crate::AgentEvent::Final { .. })
             )
         }));
     }

--- a/crates/impetus-core/src/lib.rs
+++ b/crates/impetus-core/src/lib.rs
@@ -57,6 +57,7 @@ pub use ci::{
 pub use diagnostics::{SubsystemHealth, SubsystemStatus};
 pub use durable_artifacts::{
     ArtifactMeta as DurableArtifactMeta, ArtifactRef as DurableArtifactRef, DurableArtifactStore,
+    default_artifact_root,
 };
 pub use effects::{
     AdmittedOperation, CapabilityVersion, DeferredEffect, EffectAdmission, EffectCapability,

--- a/crates/impetus-core/src/runtime.rs
+++ b/crates/impetus-core/src/runtime.rs
@@ -590,6 +590,70 @@ mod tests {
     }
 
     #[test]
+    fn reattach_recovers_the_exact_deferred_tool_arguments() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let database = root.path().join("events.sqlite3");
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir(&workspace).expect("workspace");
+        let policy = PolicyEngine::new(SandboxScope::local_workspace(&workspace));
+        let (session_id, approval_id);
+        {
+            let runtime = AgentRuntime::create_with_workspace(
+                SqliteEventStore::open(&database).expect("store"),
+                policy.clone(),
+                workspace.clone(),
+            )
+            .expect("runtime");
+            session_id = runtime.session_id();
+            runtime
+                .submit_intent("write an exact file")
+                .expect("intent");
+            runtime
+                .request_action(crate::Action {
+                    origin: ActionOrigin::Agent,
+                    kind: ActionKind::WriteFile,
+                    summary: "write_file via agent".into(),
+                    target: Some("result.txt".into()),
+                })
+                .expect("approval");
+            approval_id = runtime
+                .events()
+                .expect("events")
+                .into_iter()
+                .find_map(|event| match event.payload {
+                    EventPayload::Approval(ApprovalEvent::Requested { request }) => {
+                        Some(request.id)
+                    }
+                    _ => None,
+                })
+                .expect("approval id");
+            runtime
+                .record_deferred_tool(
+                    approval_id,
+                    "call-7".into(),
+                    "write_file".into(),
+                    serde_json::json!({"path": "result.txt", "content": "exact value"}),
+                )
+                .expect("deferred tool");
+        }
+
+        let recovered = AgentRuntime::attach(
+            SqliteEventStore::open(&database).expect("reopened store"),
+            policy,
+            session_id,
+        )
+        .expect("reattach");
+        assert_eq!(
+            recovered.deferred_tool(approval_id).expect("deferred tool"),
+            Some((
+                "call-7".into(),
+                "write_file".into(),
+                serde_json::json!({"path": "result.txt", "content": "exact value"}),
+            ))
+        );
+    }
+
+    #[test]
     fn attached_runtime_recovers_run_status() {
         let store = Arc::new(MemoryEventStore::default());
         let policy = PolicyEngine::new(SandboxScope::local_workspace("."));

--- a/crates/impetus-core/src/tool_orchestrator.rs
+++ b/crates/impetus-core/src/tool_orchestrator.rs
@@ -58,13 +58,23 @@ pub type ToolOutcomeStatus = ToolEventOutcome;
 pub struct ToolOrchestrator {
     policy: PolicyEngine,
     workspace_root: PathBuf,
+    artifact_root: PathBuf,
 }
 
 impl ToolOrchestrator {
     pub fn new(policy: PolicyEngine, workspace_root: PathBuf) -> Self {
+        Self::with_artifact_root(policy, workspace_root, crate::default_artifact_root())
+    }
+
+    pub fn with_artifact_root(
+        policy: PolicyEngine,
+        workspace_root: PathBuf,
+        artifact_root: PathBuf,
+    ) -> Self {
         Self {
             policy,
             workspace_root,
+            artifact_root,
         }
     }
 
@@ -255,12 +265,12 @@ impl ToolOrchestrator {
             },
             name => return Err(OrchestratorError::ToolNotFound(name.into())),
         };
-        let artifacts =
-            DurableArtifactStore::open(std::env::temp_dir().join("impetus-agent-artifacts"))
-                .map_err(|error| OrchestratorError::ToolFailed {
-                    tool: tool_call.name.clone(),
-                    reason: error.to_string(),
-                })?;
+        let artifacts = DurableArtifactStore::open(&self.artifact_root).map_err(|error| {
+            OrchestratorError::ToolFailed {
+                tool: tool_call.name.clone(),
+                reason: error.to_string(),
+            }
+        })?;
         let seam = EffectSeam::with_sandbox(
             self.policy.clone(),
             Sandbox::workspace(&self.workspace_root),
@@ -696,5 +706,43 @@ mod tests {
                 .expect("approved shell execution");
         assert_eq!(observation.outcome, ToolOutcomeStatus::Success);
         assert!(observation.preview.contains("verified"));
+    }
+
+    #[tokio::test]
+    async fn large_read_artifact_survives_store_reopen() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let artifact_root = tempfile::tempdir().expect("artifact root");
+        let content = "durable evidence\n".repeat(2_000);
+        std::fs::write(workspace.path().join("large.txt"), &content).expect("fixture");
+        let runtime = Arc::new(AgentRuntime::new(
+            Arc::new(MemoryEventStore::default()),
+            PolicyEngine::new(SandboxScope::local_workspace(workspace.path())),
+        ));
+        let orchestrator = ToolOrchestrator::with_artifact_root(
+            runtime.policy(),
+            workspace.path().to_path_buf(),
+            artifact_root.path().to_path_buf(),
+        );
+
+        let observation = orchestrator
+            .process_tool_calls(
+                Uuid::new_v4(),
+                vec![crate::ToolCall {
+                    id: "read-large".into(),
+                    name: "read_file".into(),
+                    arguments: serde_json::json!({"path": "large.txt"}),
+                }],
+                &runtime,
+            )
+            .await
+            .expect("read tool")
+            .pop()
+            .expect("observation");
+        let artifact = observation.artifact.expect("large output artifact");
+        let reopened = DurableArtifactStore::open(artifact_root.path()).expect("reopen store");
+        assert_eq!(
+            reopened.read(&artifact.id).expect("artifact bytes"),
+            content.as_bytes()
+        );
     }
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,10 +9,13 @@ executable tasks are in [TODO.md](../TODO.md).
 - Crate split `impetus` (client) / `impetusd` (daemon) / `impetus-core`.
 - Versioned local IPC, `HarnessClient`.
 - Safety, capability, sandbox, approval, secret-reference base.
-- `ModelProvider` и `ProviderRegistry` foundations.
-- Basic copied-event fork и compaction/budget primitives.
+- `ModelProvider` and `ProviderRegistry` foundations.
+- Basic copied-event fork and compaction/budget primitives.
 - Attachment/diff/detail DTOs with bounded **ephemeral/in-memory** backing (not durable `ArtifactStore`).
-- Agent Loop / Tool Orchestrator vertical slice: read tools execute through policy and sandbox; writes and shell commands require exact user approval, then resume with durable observations.
+- Agent Loop / Tool Orchestrator vertical slice: read tools execute through
+  policy and sandbox; writes and shell commands require exact user approval,
+  then resume with durable observations. Large read outputs are stored in the
+  durable content-addressed artifact store and referenced from the event log.
 
 ## MODULE RUNTIME / EXTENSIBILITY FOUNDATION
 
@@ -53,8 +56,9 @@ executable tasks are in [TODO.md](../TODO.md).
 
 **Current:** a working single-session vertical slice parses model tool calls,
 executes read-only tools, defers mutating tools for exact approval, and resumes
-the model from durable observations. Native provider tool-call protocols, web
-research, durable artifact backing, and model routing remain future work.
+the model from durable observations. Tool artifacts persist in the stable data
+root. Native provider tool-call protocols, web research, and model routing
+remain future work.
 
 **Target:**
 
@@ -71,8 +75,8 @@ Model → Tool Orchestrator → Tool request → Effect normalization
 and explicit safety admission for `list_files`, `read_file`, `search`,
 `write_file`, `edit_file`, and `bash`/`shell`/`exec`.
 
-**Target:** provider-native structured tool calls, durable artifact backing,
-bounded execution, and the remaining tool families.
+**Target:** provider-native structured tool calls, bounded execution, and the
+remaining tool families.
 
 ### Model Router
 


### PR DESCRIPTION
## Summary
- use stable content-addressed artifact storage for large agent read output
- derive approval details from the owning session workspace
- add durable deferred-tool recovery and cancellation E2E coverage
- align canonical English status documentation

Refs #23

## Verification
- task verify
- task ci:list