### PR TITLE
feat: add budget enforcement to AgentRuntime (refs #4)

### DIFF
--- a/crates/impetus-core/src/cost_estimation.rs
+++ b/crates/impetus-core/src/cost_estimation.rs
@@ -1,0 +1,168 @@
+//! Cost estimation utilities for token usage and budget tracking.
+
+use crate::model_router::ModelMetadata;
+
+/// Estimate cost for token usage
+pub fn estimate_cost(model: &ModelMetadata, input_tokens: u64, output_tokens: u64) -> Option<f64> {
+    model.cost_per_mtok.map(|(input_cost, output_cost)| {
+        let input_cost_usd = (input_tokens as f64 / 1_000_000.0) * input_cost;
+        let output_cost_usd = (output_tokens as f64 / 1_000_000.0) * output_cost;
+        input_cost_usd + output_cost_usd
+    })
+}
+
+/// Format cost as human-readable string
+pub fn format_cost(cost_usd: f64) -> String {
+    if cost_usd < 0.01 {
+        format!("${:.4}", cost_usd)
+    } else {
+        format!("${:.2}", cost_usd)
+    }
+}
+
+/// Estimate remaining budget
+pub fn estimate_remaining_budget(budget_tokens: Option<u64>, used_tokens: u64) -> Option<u64> {
+    budget_tokens.map(|max| max.saturating_sub(used_tokens))
+}
+
+/// Check if request would exceed budget
+pub fn would_exceed_budget(
+    budget_tokens: Option<u64>,
+    used_tokens: u64,
+    request_tokens: u64,
+) -> bool {
+    if let Some(max) = budget_tokens {
+        used_tokens + request_tokens > max
+    } else {
+        false
+    }
+}
+
+/// Budget warning thresholds
+#[derive(Debug, Clone, Copy)]
+pub enum BudgetWarningLevel {
+    /// No warning
+    None,
+    /// 50-80% used
+    Low,
+    /// 80-95% used
+    Medium,
+    /// 95%+ used
+    High,
+}
+
+impl BudgetWarningLevel {
+    pub fn from_usage_percent(percent: u8) -> Self {
+        match percent {
+            0..=49 => Self::None,
+            50..=79 => Self::Low,
+            80..=94 => Self::Medium,
+            95..=100 => Self::High,
+            _ => Self::High,
+        }
+    }
+
+    pub fn message(&self, percent: u8) -> Option<String> {
+        match self {
+            Self::None => None,
+            Self::Low => Some(format!("Budget {}% used", percent)),
+            Self::Medium => Some(format!("Budget {}% used (approaching limit)", percent)),
+            Self::High => Some(format!("Budget {}% used (critical)", percent)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_router::{ModelCapabilities, ModelMetadata};
+
+    fn mock_model(cost_per_mtok: Option<(f64, f64)>) -> ModelMetadata {
+        ModelMetadata {
+            provider_id: "test".to_string(),
+            model_id: "test-model".to_string(),
+            capabilities: ModelCapabilities {
+                tools: true,
+                reasoning: false,
+                vision: false,
+                context_window: 8192,
+            },
+            cost_per_mtok,
+            is_local: false,
+            avg_latency_ms: None,
+            health: 1.0,
+        }
+    }
+
+    #[test]
+    fn estimate_cost_calculates_correctly() {
+        let model = mock_model(Some((10.0, 30.0))); // $10/Mtok input, $30/Mtok output
+        let cost = estimate_cost(&model, 1_000_000, 500_000).unwrap();
+        assert_eq!(cost, 25.0); // $10 + $15
+    }
+
+    #[test]
+    fn estimate_cost_returns_none_for_local() {
+        let model = mock_model(None);
+        assert!(estimate_cost(&model, 1_000_000, 500_000).is_none());
+    }
+
+    #[test]
+    fn format_cost_handles_ranges() {
+        assert_eq!(format_cost(0.0001), "$0.0001");
+        assert_eq!(format_cost(0.05), "$0.05");
+        assert_eq!(format_cost(1.23), "$1.23");
+        assert_eq!(format_cost(123.45), "$123.45");
+    }
+
+    #[test]
+    fn estimate_remaining_budget_works() {
+        assert_eq!(estimate_remaining_budget(Some(1000), 300), Some(700));
+        assert_eq!(estimate_remaining_budget(Some(1000), 1200), Some(0));
+        assert_eq!(estimate_remaining_budget(None, 500), None);
+    }
+
+    #[test]
+    fn would_exceed_budget_detects_overrun() {
+        assert!(!would_exceed_budget(Some(1000), 500, 400));
+        assert!(would_exceed_budget(Some(1000), 500, 600));
+        assert!(!would_exceed_budget(None, 5000, 10000));
+    }
+
+    #[test]
+    fn budget_warning_levels() {
+        assert!(matches!(
+            BudgetWarningLevel::from_usage_percent(30),
+            BudgetWarningLevel::None
+        ));
+        assert!(matches!(
+            BudgetWarningLevel::from_usage_percent(60),
+            BudgetWarningLevel::Low
+        ));
+        assert!(matches!(
+            BudgetWarningLevel::from_usage_percent(85),
+            BudgetWarningLevel::Medium
+        ));
+        assert!(matches!(
+            BudgetWarningLevel::from_usage_percent(97),
+            BudgetWarningLevel::High
+        ));
+    }
+
+    #[test]
+    fn budget_warning_messages() {
+        assert_eq!(BudgetWarningLevel::None.message(30), None);
+        assert_eq!(
+            BudgetWarningLevel::Low.message(60),
+            Some("Budget 60% used".to_string())
+        );
+        assert_eq!(
+            BudgetWarningLevel::Medium.message(85),
+            Some("Budget 85% used (approaching limit)".to_string())
+        );
+        assert_eq!(
+            BudgetWarningLevel::High.message(97),
+            Some("Budget 97% used (critical)".to_string())
+        );
+    }
+}

--- a/crates/impetus-core/src/lib.rs
+++ b/crates/impetus-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod approval;
 pub mod attachments;
 pub mod budget;
 pub mod ci;
+pub mod cost_estimation;
 pub mod diagnostics;
 pub mod durable_artifacts;
 pub mod effects;

--- a/crates/impetus-core/src/runtime.rs
+++ b/crates/impetus-core/src/runtime.rs
@@ -1,7 +1,7 @@
 use crate::{
     Action, ApprovalEvent, ApprovalRequest, ApprovalResolution, ApprovalResolver, ApprovalState,
-    DeferredEffect, Event, EventPayload, EventStore, IntentEvent, NoticeEvent, PolicyDecision,
-    PolicyEngine, ProjectionError, RunEvent, ToolEvent, reduce,
+    BudgetChecker, BudgetConfig, DeferredEffect, Event, EventPayload, EventStore, IntentEvent,
+    NoticeEvent, PolicyDecision, PolicyEngine, ProjectionError, RunEvent, ToolEvent, reduce,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -55,6 +55,7 @@ pub struct AgentRuntime {
     store: Arc<dyn EventStore>,
     policy: PolicyEngine,
     workspace_root: PathBuf,
+    budget: Option<BudgetChecker>,
     // A2 Phase 2: Store deferred effects for approval continuation.
     // Maps approval_id -> DeferredEffect so approved work can resume.
     deferred_effects: Arc<Mutex<HashMap<Uuid, DeferredEffect>>>,
@@ -72,11 +73,13 @@ impl AgentRuntime {
     }
 
     pub fn create(store: Arc<dyn EventStore>, policy: PolicyEngine) -> Result<Self, RuntimeError> {
+        let session_id = store.create_session()?;
         Ok(Self {
-            session_id: store.create_session()?,
+            session_id,
             store,
             workspace_root: policy.scope().workspace_root.clone(),
             policy,
+            budget: None,
             deferred_effects: Arc::new(Mutex::new(HashMap::new())),
         })
     }
@@ -105,6 +108,7 @@ impl AgentRuntime {
             store,
             policy: scoped_policy,
             workspace_root,
+            budget: None,
             deferred_effects: Arc::new(Mutex::new(HashMap::new())),
         })
     }
@@ -127,6 +131,7 @@ impl AgentRuntime {
             store,
             policy: policy_for_workspace(&policy, workspace_root.clone()),
             workspace_root,
+            budget: None,
             deferred_effects: Arc::new(Mutex::new(HashMap::new())),
         })
     }
@@ -143,12 +148,49 @@ impl AgentRuntime {
             store,
             workspace_root: policy.scope().workspace_root.clone(),
             policy,
+            budget: None,
             deferred_effects: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
     pub fn session_id(&self) -> Uuid {
         self.session_id
+    }
+
+    /// Set budget configuration for this runtime
+    pub fn set_budget(&mut self, config: BudgetConfig) -> Result<(), RuntimeError> {
+        // Load existing budget state from store
+        let state = self.store.as_ref().get_budget_state(self.session_id)?;
+        self.budget = Some(BudgetChecker::new(config));
+        // Restore state
+        if let Some(ref mut checker) = self.budget {
+            *checker.state_mut() = state;
+        }
+        Ok(())
+    }
+
+    /// Get current budget state (if budget enabled)
+    pub fn budget_state(&self) -> Option<&crate::budget::BudgetState> {
+        self.budget.as_ref().map(|b| b.state())
+    }
+
+    /// Check if budget allows this request
+    pub fn check_budget(&self, estimated_tokens: u64) -> Result<(), crate::budget::BudgetError> {
+        if let Some(ref checker) = self.budget {
+            checker.check_all(estimated_tokens)?;
+        }
+        Ok(())
+    }
+
+    /// Record turn completion and persist budget state
+    pub fn record_turn(&mut self, tokens_used: u64) -> Result<(), RuntimeError> {
+        if let Some(ref mut checker) = self.budget {
+            checker.record_turn(tokens_used);
+            self.store
+                .as_ref()
+                .update_budget_state(self.session_id, checker.state())?;
+        }
+        Ok(())
     }
 
     pub fn workspace_root(&self) -> Result<PathBuf, RuntimeError> {


### PR DESCRIPTION
- Add BudgetChecker field to AgentRuntime with durable state loading
- set_budget() loads existing state from store and configures checker
- check_budget() validates requests against limits before execution
- record_turn() persists budget state after each turn
- Add cost_estimation module with utilities:
  - estimate_cost() calculates USD cost from token usage
  - format_cost() for human-readable display
  - estimate_remaining_budget() and would_exceed_budget() helpers
  - BudgetWarningLevel with threshold-based messages
- Tests: cost calculation, budget warnings, remaining budget

Phase 5 Part 2: Budget enforcement integrated into runtime.
