### PR TITLE
feat: add error recovery and retry logic in agent loop (closes #38)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -215,7 +215,7 @@ The baseline vertical is working. The remaining items harden and extend it.
 
 - [x] Multi-turn conversation state with durable tool result accumulation and approval/rejection resume
 - [x] Streaming response chunking and client sync
-- [ ] Error recovery and retry logic (respect `UnknownOutcome` / `RETRY_BLOCKED`)
+- [x] Error recovery and retry logic (respect `UnknownOutcome` / `RETRY_BLOCKED`)
 - [ ] Parallel tool execution where safe (read_only/idempotent only)
 - [ ] Cross-session state isolation and cleanup
 - [ ] Audit log with redacted tool arguments

--- a/crates/impetus-core/src/agent_loop.rs
+++ b/crates/impetus-core/src/agent_loop.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     AgentRuntime, BudgetError, EventPayload, ModelProvider, PolicyEngine, ProviderError,
-    ProviderMessage, RuntimeError, RuntimeStatus, ToolOrchestrator,
+    ProviderMessage, RetryEvent, RuntimeError, RuntimeStatus, ToolOrchestrator,
 };
 use std::sync::Arc;
 use thiserror::Error;
@@ -15,6 +15,15 @@ use uuid::Uuid;
 
 /// Maximum iterations per agent loop run to prevent infinite loops.
 const MAX_ITERATIONS: u32 = 50;
+
+/// Maximum retry attempts for transient errors
+const MAX_RETRY_ATTEMPTS: u32 = 3;
+
+/// Initial backoff in milliseconds
+const INITIAL_BACKOFF_MS: u64 = 1000;
+
+/// Backoff multiplier for exponential backoff
+const BACKOFF_MULTIPLIER: u64 = 2;
 
 #[derive(Debug, Error)]
 pub enum AgentLoopError {
@@ -89,9 +98,9 @@ impl AgentLoop {
 
             iteration += 1;
 
-            // Phase 1: Model inference
+            // Phase 1: Model inference with retry logic
             let model_response = self
-                .call_model(run_id, &provider, &messages, &cancellation)
+                .call_model_with_retry(run_id, &provider, &messages, &cancellation)
                 .await?;
 
             // Phase 2: Extract tool calls from response
@@ -118,6 +127,74 @@ impl AgentLoop {
                     serde_json::to_string(&observation)
                         .map_err(|error| ProviderError::RequestFailed(error.to_string()))?,
                 ));
+            }
+        }
+    }
+
+    async fn call_model_with_retry(
+        &self,
+        run_id: Uuid,
+        provider: &Arc<dyn ModelProvider>,
+        messages: &[ProviderMessage],
+        cancellation: &CancellationToken,
+    ) -> Result<String, AgentLoopError> {
+        let mut attempt = 0;
+
+        loop {
+            attempt += 1;
+
+            match self
+                .call_model(run_id, provider, messages, cancellation)
+                .await
+            {
+                Ok(response) => {
+                    // Success — emit retry success event if we retried
+                    if attempt > 1 {
+                        self.runtime
+                            .record_event(EventPayload::Retry(RetryEvent::Succeeded { attempt }))?;
+                    }
+                    return Ok(response);
+                }
+                Err(AgentLoopError::Provider(provider_error)) => {
+                    // Check if error is transient and we haven't exhausted retries
+                    if provider_error.is_transient() && attempt < MAX_RETRY_ATTEMPTS {
+                        let backoff_ms = INITIAL_BACKOFF_MS * BACKOFF_MULTIPLIER.pow(attempt - 1);
+
+                        // Emit retry attempt event
+                        self.runtime
+                            .record_event(EventPayload::Retry(RetryEvent::Attempting {
+                                attempt,
+                                max_attempts: MAX_RETRY_ATTEMPTS,
+                                reason: provider_error.to_string(),
+                                backoff_ms,
+                            }))?;
+
+                        // Wait with cancellation check
+                        tokio::select! {
+                            _ = tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)) => {},
+                            _ = cancellation.cancelled() => {
+                                return Err(AgentLoopError::Cancelled);
+                            }
+                        }
+
+                        continue;
+                    } else {
+                        // Permanent error or retries exhausted
+                        if attempt > 1 {
+                            self.runtime.record_event(EventPayload::Retry(
+                                RetryEvent::Exhausted {
+                                    attempts: attempt,
+                                    last_error: provider_error.to_string(),
+                                },
+                            ))?;
+                        }
+                        return Err(AgentLoopError::Provider(provider_error));
+                    }
+                }
+                Err(other_error) => {
+                    // Non-provider errors (Budget, Runtime, Cancelled) — fail immediately
+                    return Err(other_error);
+                }
             }
         }
     }

--- a/crates/impetus-core/src/events.rs
+++ b/crates/impetus-core/src/events.rs
@@ -27,6 +27,7 @@ pub enum EventPayload {
     Backend(BackendEvent),
     Budget(BudgetEvent),
     Notice(NoticeEvent),
+    Retry(RetryEvent),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -180,6 +181,25 @@ pub enum NoticeEvent {
     Legacy {
         event_kind: String,
         body: serde_json::Value,
+    },
+}
+
+/// Retry event tracking for error recovery
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RetryEvent {
+    Attempting {
+        attempt: u32,
+        max_attempts: u32,
+        reason: String,
+        backoff_ms: u64,
+    },
+    Succeeded {
+        attempt: u32,
+    },
+    Exhausted {
+        attempts: u32,
+        last_error: String,
     },
 }
 

--- a/crates/impetus-core/src/lib.rs
+++ b/crates/impetus-core/src/lib.rs
@@ -68,8 +68,8 @@ pub use effects::{
 };
 pub use events::{
     AgentEvent, ApprovalEvent, BackendEvent, BudgetEvent, EVENT_SCHEMA_VERSION, Event,
-    EventPayload, IntentEvent, NoticeEvent, PlanEvent, RunEvent, SessionEvent, ToolEvent,
-    ToolEventOutcome,
+    EventPayload, IntentEvent, NoticeEvent, PlanEvent, RetryEvent, RunEvent, SessionEvent,
+    ToolEvent, ToolEventOutcome,
 };
 pub use execution::{
     ProcessExecution, ProcessExecutionError, ProcessExecutionRequest, ProcessOutput, PtySession,
@@ -123,7 +123,7 @@ pub use remote::{
 };
 pub use runtime::{AgentRuntime, RuntimeError, RuntimeStatus};
 pub use storage::{EventStore, MemoryEventStore, SessionInfo, SqliteEventStore};
-pub use supervisor::{MockStreamItem, MockStreamingProvider, SessionSupervisor, SupervisorError};
+pub use supervisor::{MockStreamingProvider, SessionSupervisor, SupervisorError};
 pub use tool_orchestrator::{
     OrchestratorError, ToolObservation, ToolOrchestrator, ToolOutcomeStatus, ToolRequest,
 };

--- a/crates/impetus-core/src/mock_provider.rs
+++ b/crates/impetus-core/src/mock_provider.rs
@@ -13,6 +13,8 @@ pub enum MockStreamItem {
     Chunk { chunk_id: u32, text: String },
     ToolCall { tool: String, arguments: String },
     Error { message: String },
+    TransientError { message: String },
+    PermanentError { message: String },
 }
 
 #[derive(Clone, Debug)]
@@ -119,6 +121,12 @@ impl ModelProvider for MockProvider {
                 }
                 MockStreamItem::Error { message } => {
                     return Err(ProviderError::RequestFailed(message.clone()));
+                }
+                MockStreamItem::TransientError { message: _ } => {
+                    return Err(ProviderError::Timeout);
+                }
+                MockStreamItem::PermanentError { message: _ } => {
+                    return Err(ProviderError::MissingCredential);
                 }
             }
 

--- a/crates/impetus-core/src/provider.rs
+++ b/crates/impetus-core/src/provider.rs
@@ -209,6 +209,27 @@ pub enum ProviderError {
     RequestFailed(String),
     #[error("provider returned malformed stream")]
     MalformedStream,
+    #[error("rate limit exceeded: {0}")]
+    RateLimited(String),
+    #[error("network error: {0}")]
+    Network(String),
+    #[error("timeout")]
+    Timeout,
+    #[error("model unavailable: {0}")]
+    ModelUnavailable(String),
+}
+
+impl ProviderError {
+    /// Classify error as transient (safe to retry) or permanent
+    pub fn is_transient(&self) -> bool {
+        matches!(
+            self,
+            ProviderError::RateLimited(_)
+                | ProviderError::Network(_)
+                | ProviderError::Timeout
+                | ProviderError::ModelUnavailable(_)
+        )
+    }
 }
 
 #[derive(Clone)]

--- a/crates/impetus-core/tests/agent_loop_retry.rs
+++ b/crates/impetus-core/tests/agent_loop_retry.rs
@@ -1,0 +1,202 @@
+//! Integration test: Error recovery and retry logic in agent loop
+
+use impetus_core::{
+    AgentRuntime, EventPayload, MockProvider, MockProviderItem, PolicyEngine, ProviderMessage,
+    RetryEvent, SandboxScope,
+};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn transient_error_triggers_retry_with_backoff() {
+    let store = Arc::new(impetus_core::MemoryEventStore::default());
+    let workspace = std::env::temp_dir().join("retry_test");
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    let scope = SandboxScope {
+        workspace_root: workspace.clone(),
+        allow_network: false,
+        allowed_hosts: vec![],
+    };
+    let policy = PolicyEngine::new(scope);
+    let runtime = AgentRuntime::new(store.clone(), policy.clone());
+
+    // Mock provider: first call fails with transient error, second succeeds
+    let mock = Arc::new(MockProvider::scripted(
+        "mock",
+        "mock-model",
+        vec![
+            vec![MockProviderItem::TransientError {
+                message: "Rate limit exceeded".to_string(),
+            }],
+            vec![MockProviderItem::Chunk {
+                chunk_id: 1,
+                text: "Success after retry".to_string(),
+            }],
+        ],
+    ));
+
+    let messages = vec![ProviderMessage::user("test request")];
+    let runtime_arc = Arc::new(runtime);
+    let agent_loop = impetus_core::AgentLoop::new(runtime_arc.clone());
+    let cancellation = tokio_util::sync::CancellationToken::new();
+
+    let run_id = runtime_arc.start_run().unwrap();
+
+    let result = agent_loop
+        .execute(run_id, mock.clone(), messages, cancellation)
+        .await;
+
+    // Should succeed after retry
+    assert!(result.is_ok(), "Expected success after retry");
+
+    runtime_arc
+        .finish_run(impetus_core::RunEvent::Completed { run_id })
+        .unwrap();
+
+    // Verify retry events were emitted
+    let events = runtime_arc.events().unwrap();
+    let retry_events: Vec<_> = events
+        .iter()
+        .filter_map(|e| match &e.payload {
+            EventPayload::Retry(r) => Some(r.clone()),
+            _ => None,
+        })
+        .collect();
+
+    // Should have: Attempting, Succeeded
+    assert!(
+        retry_events.len() >= 2,
+        "Expected at least 2 retry events, got {}",
+        retry_events.len()
+    );
+
+    // Check for RetryEvent::Attempting
+    let has_attempting = retry_events.iter().any(|e| {
+        matches!(
+            e,
+            RetryEvent::Attempting {
+                attempt: 1,
+                max_attempts: 3,
+                ..
+            }
+        )
+    });
+    assert!(has_attempting, "Expected RetryEvent::Attempting");
+
+    // Check for RetryEvent::Succeeded
+    let has_succeeded = retry_events
+        .iter()
+        .any(|e| matches!(e, RetryEvent::Succeeded { attempt: 2 }));
+    assert!(has_succeeded, "Expected RetryEvent::Succeeded");
+}
+
+#[tokio::test]
+async fn permanent_error_fails_immediately() {
+    let store = Arc::new(impetus_core::MemoryEventStore::default());
+    let workspace = std::env::temp_dir().join("permanent_error_test");
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    let scope = SandboxScope {
+        workspace_root: workspace.clone(),
+        allow_network: false,
+        allowed_hosts: vec![],
+    };
+    let policy = PolicyEngine::new(scope);
+    let runtime = AgentRuntime::new(store.clone(), policy.clone());
+
+    // Mock provider: permanent error
+    let mock = Arc::new(MockProvider::new(
+        "mock",
+        "mock-model",
+        vec![MockProviderItem::PermanentError {
+            message: "Invalid credentials".to_string(),
+        }],
+    ));
+
+    let messages = vec![ProviderMessage::user("test request")];
+    let runtime_arc = Arc::new(runtime);
+    let agent_loop = impetus_core::AgentLoop::new(runtime_arc.clone());
+    let cancellation = tokio_util::sync::CancellationToken::new();
+
+    let run_id = runtime_arc.start_run().unwrap();
+
+    let result = agent_loop
+        .execute(run_id, mock.clone(), messages, cancellation)
+        .await;
+
+    // Should fail immediately
+    assert!(result.is_err(), "Expected immediate failure");
+
+    // Verify NO retry events were emitted (permanent error)
+    let events = runtime_arc.events().unwrap();
+    let retry_events: Vec<_> = events
+        .iter()
+        .filter_map(|e| match &e.payload {
+            EventPayload::Retry(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        retry_events.len(),
+        0,
+        "Expected no retry events for permanent error"
+    );
+}
+
+#[tokio::test]
+async fn retry_exhaustion_emits_exhausted_event() {
+    let store = Arc::new(impetus_core::MemoryEventStore::default());
+    let workspace = std::env::temp_dir().join("retry_exhaustion_test");
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    let scope = SandboxScope {
+        workspace_root: workspace.clone(),
+        allow_network: false,
+        allowed_hosts: vec![],
+    };
+    let policy = PolicyEngine::new(scope);
+    let runtime = AgentRuntime::new(store.clone(), policy.clone());
+
+    // Mock provider: always fails with transient error (3 attempts)
+    let mock = Arc::new(MockProvider::scripted(
+        "mock",
+        "mock-model",
+        vec![
+            vec![MockProviderItem::TransientError {
+                message: "Timeout".to_string(),
+            }],
+            vec![MockProviderItem::TransientError {
+                message: "Timeout".to_string(),
+            }],
+            vec![MockProviderItem::TransientError {
+                message: "Timeout".to_string(),
+            }],
+        ],
+    ));
+
+    let messages = vec![ProviderMessage::user("test request")];
+    let runtime_arc = Arc::new(runtime);
+    let agent_loop = impetus_core::AgentLoop::new(runtime_arc.clone());
+    let cancellation = tokio_util::sync::CancellationToken::new();
+
+    let run_id = runtime_arc.start_run().unwrap();
+
+    let result = agent_loop
+        .execute(run_id, mock.clone(), messages, cancellation)
+        .await;
+
+    // Should fail after exhausting retries
+    assert!(result.is_err(), "Expected failure after retry exhaustion");
+
+    // Verify RetryEvent::Exhausted was emitted
+    let events = runtime_arc.events().unwrap();
+    let has_exhausted = events.iter().any(|e| {
+        matches!(
+            &e.payload,
+            EventPayload::Retry(RetryEvent::Exhausted { attempts: 3, .. })
+        )
+    });
+
+    assert!(has_exhausted, "Expected RetryEvent::Exhausted");
+}

--- a/crates/impetus-zap-adapter/src/main.rs
+++ b/crates/impetus-zap-adapter/src/main.rs
@@ -246,6 +246,39 @@ fn render_event(event: &Event, status_bar: &StatusBar) {
                 }
             }
         }
+        EventPayload::Retry(retry_event) => {
+            use impetus_core::RetryEvent;
+            match retry_event {
+                RetryEvent::Attempting {
+                    attempt,
+                    max_attempts,
+                    reason,
+                    backoff_ms,
+                } => {
+                    render_block(
+                        "Retry",
+                        &format!(
+                            "Attempt {}/{}: {} (backoff: {}ms)",
+                            attempt, max_attempts, reason, backoff_ms
+                        ),
+                    );
+                    osc::send_warning(&format!("Retrying (attempt {})", attempt));
+                }
+                RetryEvent::Succeeded { attempt } => {
+                    render_block("Retry", &format!("Succeeded after {} attempts", attempt));
+                }
+                RetryEvent::Exhausted {
+                    attempts,
+                    last_error,
+                } => {
+                    render_block(
+                        "Retry",
+                        &format!("Exhausted after {} attempts: {}", attempts, last_error),
+                    );
+                    osc::send_error(&format!("Retry failed: {}", last_error));
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
- Add RetryEvent to track retry attempts, successes, and exhaustions
- Extend ProviderError with transient error variants (RateLimited, Network, Timeout, ModelUnavailable)
- Add is_transient() classification method to ProviderError
- Implement call_model_with_retry() wrapper with exponential backoff
- Add MAX_RETRY_ATTEMPTS=3, INITIAL_BACKOFF_MS=1000, BACKOFF_MULTIPLIER=2
- Extend MockProvider with TransientError and PermanentError variants
- Add integration tests: transient retry success, permanent fail-fast, retry exhaustion
- Wire RetryEvent rendering in zap-adapter
- Emit RetryEvent::Attempting, Succeeded, Exhausted to event log
