### PR TITLE
fix: remove unused imports in parallel tool test

### DIFF
--- a/crates/impetus-core/tests/tool_orchestrator_parallel.rs
+++ b/crates/impetus-core/tests/tool_orchestrator_parallel.rs
@@ -1,10 +1,6 @@
 //! Integration test: Parallel tool execution for read-only and idempotent tools
 
-use impetus_core::{
-    Action, ActionKind, ActionOrigin, AgentRuntime, PolicyEngine, SandboxScope, ToolCall,
-    ToolOrchestrator,
-};
-use std::path::PathBuf;
+use impetus_core::{AgentRuntime, PolicyEngine, SandboxScope, ToolCall, ToolOrchestrator};
 use std::sync::Arc;
 use std::time::Instant;
 


### PR DESCRIPTION
Fixes CI failures from #41:
- Remove unused Action, ActionKind, ActionOrigin imports
- Remove unused PathBuf import  
- Fix rustfmt formatting for imports

Refs #39