### PR TITLE
feat: implement agent skills adapter with SKILL.md parser (closes #56)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "tempfile",
  "thiserror 2.0.20",
@@ -1991,6 +1992,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2385,6 +2399,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/crates/impetus-core/Cargo.toml
+++ b/crates/impetus-core/Cargo.toml
@@ -24,6 +24,7 @@ async-trait = "0.1.92"
 base64 = "0.23.1"
 regex = "1.11.1"
 chrono = "0.4.45"
+serde_yaml = "0.9"
 
 [dev-dependencies]
 tempfile = "3.15"

--- a/crates/impetus-core/src/agent_skills_adapter.rs
+++ b/crates/impetus-core/src/agent_skills_adapter.rs
@@ -1,0 +1,233 @@
+use crate::extension_compat::{
+    CanonicalModuleKind, CanonicalModuleSpec, CanonicalSkill, ExtensionSource, Instruction,
+    InstructionContext, InstructionPriority,
+};
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Agent Skills frontmatter
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct SkillFrontmatter {
+    name: String,
+    description: String,
+    #[serde(default)]
+    triggers: Vec<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    author: Option<String>,
+    #[serde(flatten)]
+    extra: HashMap<String, serde_json::Value>,
+}
+
+/// Agent Skills adapter
+pub struct AgentSkillsAdapter;
+
+impl AgentSkillsAdapter {
+    /// Parse SKILL.md file
+    pub async fn parse_skill(path: &Path) -> Result<CanonicalSkill> {
+        let content = tokio::fs::read_to_string(path)
+            .await
+            .context("Failed to read SKILL.md")?;
+
+        let (frontmatter, body) = Self::extract_frontmatter(&content)?;
+
+        let skill_id = frontmatter.name.to_lowercase().replace(' ', "-");
+
+        let instructions = vec![Instruction {
+            content: body.trim().to_string(),
+            context: InstructionContext::Task,
+            priority: InstructionPriority::High,
+        }];
+
+        let mut metadata = HashMap::new();
+        if let Some(author) = frontmatter.author {
+            metadata.insert("author".to_string(), serde_json::json!(author));
+        }
+        for (k, v) in frontmatter.extra {
+            metadata.insert(k, v);
+        }
+
+        Ok(CanonicalSkill {
+            id: skill_id.clone(),
+            name: frontmatter.name.clone(),
+            description: frontmatter.description.clone(),
+            instructions,
+            tools: vec![],
+            triggers: frontmatter.triggers.clone(),
+            metadata,
+        })
+    }
+
+    /// Convert CanonicalSkill to CanonicalModuleSpec
+    pub fn to_module_spec(skill: &CanonicalSkill, version: Option<String>) -> CanonicalModuleSpec {
+        let mut capabilities = vec!["instructions".to_string()];
+        if !skill.triggers.is_empty() {
+            capabilities.push("triggers".to_string());
+        }
+        if !skill.tools.is_empty() {
+            capabilities.push("tools".to_string());
+        }
+
+        CanonicalModuleSpec {
+            id: skill.id.clone(),
+            name: skill.name.clone(),
+            version: version.unwrap_or_else(|| "1.0.0".to_string()),
+            source: ExtensionSource::AgentSkills,
+            kind: CanonicalModuleKind::Skill,
+            capabilities,
+            metadata: skill.metadata.clone(),
+        }
+    }
+
+    /// Import skill from path
+    pub async fn import(path: &Path) -> Result<(CanonicalSkill, CanonicalModuleSpec)> {
+        let skill = Self::parse_skill(path).await?;
+        let version = skill
+            .metadata
+            .get("version")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let spec = Self::to_module_spec(&skill, version);
+        Ok((skill, spec))
+    }
+
+    /// Extract YAML frontmatter and markdown body
+    fn extract_frontmatter(content: &str) -> Result<(SkillFrontmatter, String)> {
+        let lines: Vec<&str> = content.lines().collect();
+
+        if lines.is_empty() || lines[0] != "---" {
+            anyhow::bail!("Missing YAML frontmatter (expected leading ---)");
+        }
+
+        let end_idx = lines[1..]
+            .iter()
+            .position(|&line| line == "---")
+            .context("Missing closing --- for frontmatter")?
+            + 1;
+
+        let frontmatter_lines = &lines[1..end_idx];
+        let frontmatter_text = frontmatter_lines.join("\n");
+
+        let frontmatter: SkillFrontmatter =
+            serde_yaml::from_str(&frontmatter_text).context("Failed to parse YAML frontmatter")?;
+
+        let body = lines[end_idx + 1..].join("\n");
+
+        Ok((frontmatter, body))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn extract_frontmatter_valid() {
+        let content = r#"---
+name: test-skill
+description: A test skill
+triggers:
+  - test
+  - example
+---
+
+# Test Skill
+
+This is the skill body.
+"#;
+
+        let (frontmatter, body) = AgentSkillsAdapter::extract_frontmatter(content).unwrap();
+        assert_eq!(frontmatter.name, "test-skill");
+        assert_eq!(frontmatter.description, "A test skill");
+        assert_eq!(frontmatter.triggers.len(), 2);
+        assert!(body.contains("# Test Skill"));
+    }
+
+    #[test]
+    fn extract_frontmatter_missing_delimiter() {
+        let content = "name: test\ndescription: no delimiters";
+        let result = AgentSkillsAdapter::extract_frontmatter(content);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn parse_skill_creates_canonical() {
+        let content = r#"---
+name: Example Skill
+description: An example skill for testing
+triggers:
+  - example
+  - test
+version: "1.0.0"
+author: "Test Author"
+---
+
+# Example Skill
+
+Use this skill for testing.
+"#;
+
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+
+        let skill = AgentSkillsAdapter::parse_skill(file.path()).await.unwrap();
+
+        assert_eq!(skill.id, "example-skill");
+        assert_eq!(skill.name, "Example Skill");
+        assert_eq!(skill.triggers.len(), 2);
+        assert_eq!(skill.instructions.len(), 1);
+        assert!(skill.instructions[0].content.contains("Use this skill"));
+        assert_eq!(
+            skill.metadata.get("author").unwrap().as_str().unwrap(),
+            "Test Author"
+        );
+    }
+
+    #[tokio::test]
+    async fn import_produces_both_types() {
+        let content = r#"---
+name: Import Test
+description: Test import
+---
+
+Body content.
+"#;
+
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+
+        let (skill, spec) = AgentSkillsAdapter::import(file.path()).await.unwrap();
+
+        assert_eq!(skill.id, "import-test");
+        assert_eq!(spec.id, "import-test");
+        assert_eq!(spec.source, ExtensionSource::AgentSkills);
+        assert_eq!(spec.kind, CanonicalModuleKind::Skill);
+        assert!(spec.capabilities.contains(&"instructions".to_string()));
+    }
+
+    #[test]
+    fn to_module_spec_includes_capabilities() {
+        let skill = CanonicalSkill {
+            id: "test".to_string(),
+            name: "Test".to_string(),
+            description: "Test".to_string(),
+            instructions: vec![],
+            tools: vec![],
+            triggers: vec!["trigger1".to_string()],
+            metadata: HashMap::new(),
+        };
+
+        let spec = AgentSkillsAdapter::to_module_spec(&skill, None);
+        assert!(spec.capabilities.contains(&"instructions".to_string()));
+        assert!(spec.capabilities.contains(&"triggers".to_string()));
+        assert_eq!(spec.version, "1.0.0");
+    }
+}

--- a/crates/impetus-core/src/lib.rs
+++ b/crates/impetus-core/src/lib.rs
@@ -4,6 +4,7 @@
 //! makes permission decisions, and exposes small capability seams for the app.
 
 pub mod agent_loop;
+pub mod agent_skills_adapter;
 pub mod approval;
 pub mod attachments;
 pub mod audit_log;
@@ -48,6 +49,7 @@ pub mod tool_orchestrator;
 pub mod tools;
 
 pub use agent_loop::{AgentLoop, AgentLoopError, ToolCall};
+pub use agent_skills_adapter::AgentSkillsAdapter;
 pub use approval::{
     ApprovalDetail, ApprovalId, ApprovalRequest, ApprovalResolution, ApprovalResolver,
     ApprovalState, ScopeEstimate,

--- a/crates/impetus-core/tests/agent_skills_integration.rs
+++ b/crates/impetus-core/tests/agent_skills_integration.rs
@@ -1,0 +1,159 @@
+use impetus_core::{
+    AgentSkillsAdapter, ExtensionAdapter, ExtensionRegistry, ExtensionSource, ImportCapability,
+};
+use std::path::PathBuf;
+
+#[tokio::test]
+async fn import_brainstorming_skill_from_home() {
+    let home = std::env::var("HOME").expect("HOME not set");
+    let skill_dir = PathBuf::from(home).join(".agents/skills/brainstorming");
+
+    if !skill_dir.exists() {
+        eprintln!(
+            "Skipping test: ~/.agents/skills/brainstorming not found (expected in user environment)"
+        );
+        return;
+    }
+
+    let adapter = ExtensionAdapter::new();
+    let result = adapter
+        .import(ExtensionSource::AgentSkills, &skill_dir)
+        .await
+        .expect("Import should succeed");
+
+    assert_eq!(result.source, ExtensionSource::AgentSkills);
+    assert_eq!(result.capability, ImportCapability::Supported);
+    assert!(result.canonical.is_some());
+    assert!(result.errors.is_empty());
+
+    let spec = result.canonical.unwrap();
+    assert_eq!(spec.id, "brainstorming");
+    assert_eq!(spec.name, "brainstorming");
+    assert!(spec.capabilities.contains(&"instructions".to_string()));
+    assert!(spec.capabilities.contains(&"triggers".to_string()));
+}
+
+#[tokio::test]
+async fn parse_brainstorming_skill_directly() {
+    let home = std::env::var("HOME").expect("HOME not set");
+    let skill_path = PathBuf::from(home)
+        .join(".agents/skills/brainstorming")
+        .join("SKILL.md");
+
+    if !skill_path.exists() {
+        eprintln!("Skipping test: {:?} not found", skill_path);
+        return;
+    }
+
+    let (skill, spec) = AgentSkillsAdapter::import(&skill_path)
+        .await
+        .expect("Parse should succeed");
+
+    assert_eq!(skill.id, "brainstorming");
+    assert_eq!(skill.name, "brainstorming");
+    assert!(!skill.instructions.is_empty());
+    assert!(skill.instructions[0].content.len() > 100);
+    assert!(
+        skill.instructions[0]
+            .content
+            .contains("Brainstorming Ideas Into Designs")
+    );
+
+    assert_eq!(spec.source, ExtensionSource::AgentSkills);
+    assert_eq!(spec.kind, impetus_core::CanonicalModuleKind::Skill);
+}
+
+#[tokio::test]
+async fn register_imported_skill() {
+    let home = std::env::var("HOME").expect("HOME not set");
+    let skill_dir = PathBuf::from(home).join(".agents/skills/brainstorming");
+
+    if !skill_dir.exists() {
+        eprintln!("Skipping test: brainstorming skill not found");
+        return;
+    }
+
+    let adapter = ExtensionAdapter::new();
+    let result = adapter
+        .import(ExtensionSource::AgentSkills, &skill_dir)
+        .await
+        .expect("Import should succeed");
+
+    assert!(result.canonical.is_some());
+    let spec = result.canonical.unwrap();
+
+    let registry = ExtensionRegistry::new();
+    registry
+        .register(spec.clone())
+        .expect("Registration should succeed");
+
+    let retrieved = registry.get("brainstorming");
+    assert!(retrieved.is_some());
+    assert_eq!(retrieved.unwrap().id, "brainstorming");
+
+    let by_source = registry.list_by_source(&ExtensionSource::AgentSkills);
+    assert_eq!(by_source.len(), 1);
+    assert_eq!(by_source[0].id, "brainstorming");
+}
+
+#[tokio::test]
+async fn import_missing_skill_warns() {
+    let adapter = ExtensionAdapter::new();
+    let result = adapter
+        .import(
+            ExtensionSource::AgentSkills,
+            std::path::Path::new("/tmp/nonexistent-skill"),
+        )
+        .await
+        .expect("Import should return result");
+
+    assert_eq!(result.capability, ImportCapability::Unsupported);
+    assert!(result.canonical.is_none());
+    assert!(!result.warnings.is_empty());
+    assert!(result.warnings[0].contains("SKILL.md not found"));
+}
+
+#[tokio::test]
+async fn import_multiple_skills() {
+    let home = std::env::var("HOME").expect("HOME not set");
+    let skills_root = PathBuf::from(home).join(".agents/skills");
+
+    if !skills_root.exists() {
+        eprintln!("Skipping test: ~/.agents/skills not found");
+        return;
+    }
+
+    let adapter = ExtensionAdapter::new();
+    let registry = ExtensionRegistry::new();
+
+    let mut imported_count = 0;
+    let skill_names = ["brainstorming", "writing-plans"];
+
+    for skill_name in skill_names {
+        let skill_dir = skills_root.join(skill_name);
+        if !skill_dir.exists() {
+            continue;
+        }
+
+        let result = adapter
+            .import(ExtensionSource::AgentSkills, &skill_dir)
+            .await
+            .expect("Import should succeed");
+
+        if let (ImportCapability::Supported, Some(spec)) =
+            (result.capability, result.canonical)
+        {
+            registry
+                .register(spec)
+                .expect("Registration should succeed");
+            imported_count += 1;
+        }
+    }
+
+    if imported_count > 0 {
+        let all_skills = registry.list_by_source(&ExtensionSource::AgentSkills);
+        assert_eq!(all_skills.len(), imported_count);
+    } else {
+        eprintln!("No skills found for multi-import test");
+    }
+}


### PR DESCRIPTION
- Add AgentSkillsAdapter with YAML frontmatter parser
- Parse SKILL.md to CanonicalSkill and CanonicalModuleSpec
- Wire adapter into ExtensionAdapter import flow
- Update compatibility matrix: instructions+triggers supported
- Add integration tests with real ~/.agents/skills
- Add serde_yaml dependency to impetus-core
