### PR TITLE
fix: wire agent skills adapter into extension adapter import flow

### DIFF
--- a/crates/impetus-core/src/extension_adapter.rs
+++ b/crates/impetus-core/src/extension_adapter.rs
@@ -1,3 +1,4 @@
+use crate::agent_skills_adapter::AgentSkillsAdapter;
 use crate::extension_compat::{
     CanonicalModuleSpec, CompatibilityMatrix, ExtensionSource, ImportCapability, ImportResult,
 };
@@ -58,19 +59,57 @@ impl ExtensionAdapter {
             });
         }
 
-        // Attempt import (placeholder for actual implementation)
-        warnings.push(format!(
-            "Import from {:?} at {:?} not yet implemented",
-            source, path
-        ));
+        // Attempt real import for Agent Skills
+        match source {
+            ExtensionSource::AgentSkills => {
+                let skill_path = path.join("SKILL.md");
+                if !skill_path.exists() {
+                    warnings.push(format!("SKILL.md not found at {:?}", skill_path));
+                    return Ok(ImportResult {
+                        source,
+                        capability: ImportCapability::Unsupported,
+                        canonical: None,
+                        warnings,
+                        errors,
+                    });
+                }
 
-        Ok(ImportResult {
-            source,
-            capability: overall_capability,
-            canonical: None,
-            warnings,
-            errors,
-        })
+                match AgentSkillsAdapter::import(&skill_path).await {
+                    Ok((_skill, spec)) => Ok(ImportResult {
+                        source,
+                        capability: ImportCapability::Supported,
+                        canonical: Some(spec),
+                        warnings,
+                        errors,
+                    }),
+                    Err(e) => {
+                        errors.push(format!("Failed to parse SKILL.md: {}", e));
+                        Ok(ImportResult {
+                            source,
+                            capability: ImportCapability::Incompatible,
+                            canonical: None,
+                            warnings,
+                            errors,
+                        })
+                    }
+                }
+            }
+            _ => {
+                // Other sources still unsupported
+                warnings.push(format!(
+                    "Import from {:?} at {:?} not yet implemented",
+                    source, path
+                ));
+
+                Ok(ImportResult {
+                    source,
+                    capability: overall_capability,
+                    canonical: None,
+                    warnings,
+                    errors,
+                })
+            }
+        }
     }
 
     /// Assess overall capability from matrix

--- a/crates/impetus-core/src/extension_compat.rs
+++ b/crates/impetus-core/src/extension_compat.rs
@@ -213,15 +213,15 @@ impl CompatibilityMatrix {
     /// Get compatibility matrix for Agent Skills
     pub fn agent_skills() -> Self {
         let mut capabilities = HashMap::new();
-        capabilities.insert("instructions".to_string(), ImportCapability::Unsupported);
+        capabilities.insert("instructions".to_string(), ImportCapability::Supported);
         capabilities.insert("tools".to_string(), ImportCapability::Unsupported);
-        capabilities.insert("triggers".to_string(), ImportCapability::Unsupported);
+        capabilities.insert("triggers".to_string(), ImportCapability::Supported);
         capabilities.insert("profiles".to_string(), ImportCapability::Unsupported);
 
         Self {
             source: ExtensionSource::AgentSkills,
             capabilities,
-            notes: vec!["Requires upstream spec audit before implementation".to_string()],
+            notes: vec!["SKILL.md parser implemented with frontmatter support".to_string()],
         }
     }
 

--- a/crates/impetus-core/tests/agent_skills_integration.rs
+++ b/crates/impetus-core/tests/agent_skills_integration.rs
@@ -140,9 +140,7 @@ async fn import_multiple_skills() {
             .await
             .expect("Import should succeed");
 
-        if let (ImportCapability::Supported, Some(spec)) =
-            (result.capability, result.canonical)
-        {
+        if let (ImportCapability::Supported, Some(spec)) = (result.capability, result.canonical) {
             registry
                 .register(spec)
                 .expect("Registration should succeed");


### PR DESCRIPTION
- Update compatibility matrix: instructions+triggers now Supported
- Add real AgentSkillsAdapter::import() call in ExtensionAdapter
- Handle missing SKILL.md with proper warning message
- Fix import_missing_skill_warns test that was failing in CI
