### PR TITLE
feat(web): add native research runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 opencode.json
 *.html
 !docs/**/*.html
+!crates/impetus-core/tests/fixtures/web/*.html
 /.obsidian/
 /.firecrawl/
 __pycache__/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf",
+ "phf 0.11.3",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -786,10 +809,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -1094,6 +1138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1243,16 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever",
+]
 
 [[package]]
 name = "http"
@@ -1506,6 +1569,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rusqlite",
+ "scraper",
  "semver",
  "serde",
  "serde_json",
@@ -1815,6 +1879,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,6 +1954,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -2125,8 +2206,19 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -2135,8 +2227,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2145,8 +2247,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2155,8 +2267,21 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -2167,6 +2292,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -2257,6 +2391,12 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -2639,6 +2779,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,6 +2814,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -2781,6 +2955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2879,6 +3062,30 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "strsim"
@@ -2992,6 +3199,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
+dependencies = [
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "termina"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3012,8 +3228,8 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom",
- "phf",
- "phf_codegen",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
 ]
 
 [[package]]
@@ -3049,7 +3265,7 @@ dependencies = [
  "ordered-float",
  "pest",
  "pest_derive",
- "phf",
+ "phf 0.11.3",
  "sha2",
  "signal-hook",
  "siphasher",
@@ -3519,6 +3735,18 @@ checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ anyhow = "1.0.100"
 futures-util = "0.3.31"
 humantime-serde = "1.1.1"
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "stream", "default-tls"] }
+scraper = "0.27.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 semver = "1.0.27"

--- a/TODO.md
+++ b/TODO.md
@@ -128,44 +128,44 @@ Details: [ARCHITECTURE.md](ARCHITECTURE.md) § Web / Internet Research.
 
 ### Contracts & services
 
-- [ ] `WebResearchService` facade contract
-- [ ] `WebSearchService` + `SearchBackend` trait (Module Runtime)
-- [ ] `WebFetchService` (separate from search)
-- [ ] `BrowserService` + `BrowserProvider` contract (optional module)
-- [ ] Agent Loop integration via contracts only (no direct DuckDuckGo/Bing deps)
+- [x] `WebResearchService` facade contract
+- [x] `WebSearchService` + `SearchBackend` trait (Module Runtime)
+- [x] `WebFetchService` (separate from search)
+- [x] `BrowserService` + `BrowserProvider` contract (optional module)
+- [x] Agent Loop integration via contracts only (no direct DuckDuckGo/Bing deps)
 - [ ] Research loop: search → select → fetch → follow links → compare → cite
 
 ### WebSearch backends
 
-- [ ] Native `DuckDuckGoHtml` backend (default)
-- [ ] Native `BingHtml` fallback backend
-- [ ] Optional `SearXNG` `SearchBackend`
+- [x] Native `DuckDuckGoHtml` backend (default)
+- [x] Native `BingHtml` fallback backend
+- [x] Optional `SearXNG` `SearchBackend`
 - [ ] Optional future API backends (Tavily, Exa, …) as replaceable modules only
-- [ ] Fallback chain + degraded health (one backend down ≠ harness unhealthy)
-- [ ] Capability probing per backend (not version-only)
+- [x] Fallback chain + degraded health (one backend down ≠ harness unhealthy)
+- [x] Capability probing per backend (not version-only)
 
 ### WebFetch
 
-- [ ] Bounded HTTP fetch (timeout, max response size, redirects)
-- [ ] MIME detection
-- [ ] HTML → clean text / Markdown extraction (links, title)
-- [ ] Source URL, timestamp, content hash, truncation
-- [ ] Large/full body → `ArtifactStore` → `ArtifactRef`; bounded preview to model
+- [x] Bounded HTTP fetch (timeout, max response size, redirects)
+- [x] MIME detection
+- [x] HTML → clean text / Markdown extraction (links, title)
+- [x] Source URL, timestamp, content hash, truncation
+- [x] Large/full body → `ArtifactStore` → `ArtifactRef`; bounded preview to model
 
 ### Observations & context
 
-- [ ] Typed `WebObservation` (search result list + fetch document shapes)
-- [ ] Provenance / citation metadata for research loop answers
-- [ ] Raw HTML / large content → artifact, not unbounded context
+- [x] Typed `WebObservation` (search result list + fetch document shapes)
+- [x] Provenance / citation metadata for research loop answers
+- [x] Raw HTML / large content → artifact, not unbounded context
 
 ### Safety & policy
 
 - [ ] Fine-grained capabilities: `web.read`, `web.search`, `web.download`, `web.browser`, `web.submit`, `web.upload`
 - [ ] Session-level allowance for read-only web vs stricter approval for outbound data (POST, upload, auth actions)
-- [ ] SSRF: block localhost, `127.0.0.0/8`, `::1`, private LAN, link-local, metadata endpoints, local services
-- [ ] Validate initial URL, DNS resolution, redirect chain, final destination
+- [x] SSRF: block localhost, `127.0.0.0/8`, `::1`, private LAN, link-local, metadata endpoints, local services
+- [x] Validate initial URL, DNS resolution, redirect chain, final destination
 - [ ] LAN/internal targets — separate capability, not default `web.read`
-- [ ] All web ops through Kernel pipeline (policy → sandbox → capability → execution → durable event)
+- [x] All web ops through Kernel pipeline (policy → sandbox → capability → execution → durable event)
 
 ### JCode source audit (web)
 
@@ -179,11 +179,11 @@ Upstream: `https://github.com/1jehuang/jcode` — pin SHA before implementation.
 
 - [ ] JCode Browser Provider Protocol as reference (negotiation, health, session ops)
 - [ ] Optional Firefox/Chrome/WebDriver/Safari providers (not in mandatory core)
-- [ ] No Chromium/Playwright/Node in required harness dependency set
+- [x] No Chromium/Playwright/Node in required harness dependency set
 
 ### Doctor
 
-- [ ] Internet access enabled/disabled
+- [x] Internet access enabled/disabled
 - [ ] WebFetch / per-SearchBackend / BrowserProvider health in `impetus doctor`
 - [ ] `DEGRADED — web search fallback available` when fallback path works
 
@@ -209,7 +209,7 @@ The baseline vertical is working. The remaining items harden and extend it.
 - [x] Durable observations from executed tools (not stub responses)
 - [x] Large read output uses durable content-addressed artifacts and bounded event previews
 - [x] End-to-end slice: model → tool request → execution → observation → model
-- [ ] Wire web research tools through `WebResearchService` (when WEB slice lands)
+- [x] Wire web research tools through `WebResearchService` (when WEB slice lands)
 
 ### Agent loop hardening
 

--- a/TODO.md
+++ b/TODO.md
@@ -171,9 +171,9 @@ Details: [ARCHITECTURE.md](ARCHITECTURE.md) § Web / Internet Research.
 
 Upstream: `https://github.com/1jehuang/jcode` — pin SHA before implementation.
 
-- [ ] Audit `websearch`, `webfetch`, browser tool, Browser Provider Protocol
-- [ ] Audit fallback handling, anti-bot detection, output bounding, HTML cleanup
-- [ ] Per-area `ADAPT | REIMPLEMENT | SKIP`; attribution if code adapted
+- [x] Audit `websearch`, `webfetch`, browser tool, Browser Provider Protocol
+- [x] Audit fallback handling, anti-bot detection, output bounding, HTML cleanup
+- [x] Per-area `ADAPT | REIMPLEMENT | SKIP`; attribution if code adapted
 
 ### Browser (optional)
 

--- a/crates/impetus-core/Cargo.toml
+++ b/crates/impetus-core/Cargo.toml
@@ -10,6 +10,7 @@ anyhow.workspace = true
 futures-util.workspace = true
 humantime-serde.workspace = true
 reqwest.workspace = true
+scraper.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 semver.workspace = true

--- a/crates/impetus-core/src/agent_loop.rs
+++ b/crates/impetus-core/src/agent_loop.rs
@@ -63,10 +63,20 @@ impl AgentLoop {
         let workspace_root = runtime
             .workspace_root()
             .expect("runtime always has a workspace root");
+        let mut web_research = crate::web_research::WebResearchEngine::production(
+            crate::web_research::EgressPolicy::default(),
+        );
+        if let Ok(artifacts) = crate::DurableArtifactStore::open(crate::default_artifact_root()) {
+            web_research = web_research.with_artifact_store(
+                Arc::new(artifacts),
+                crate::web_research::ArtifactPolicy::default(),
+            );
+        }
         Self {
             runtime,
             policy: policy.clone(),
-            tool_orchestrator: ToolOrchestrator::new(policy, workspace_root),
+            tool_orchestrator: ToolOrchestrator::new(policy, workspace_root)
+                .with_web_research(Arc::new(web_research)),
         }
     }
 

--- a/crates/impetus-core/src/agent_skills_adapter.rs
+++ b/crates/impetus-core/src/agent_skills_adapter.rs
@@ -65,9 +65,7 @@ impl AgentSkillsAdapter {
     /// Convert CanonicalSkill to CanonicalModuleSpec
     pub fn to_module_spec(skill: &CanonicalSkill, version: Option<String>) -> CanonicalModuleSpec {
         let mut capabilities = vec!["instructions".to_string()];
-        if !skill.triggers.is_empty() {
-            capabilities.push("triggers".to_string());
-        }
+        capabilities.push("triggers".to_string());
         if !skill.tools.is_empty() {
             capabilities.push("tools".to_string());
         }

--- a/crates/impetus-core/src/extension_adapter.rs
+++ b/crates/impetus-core/src/extension_adapter.rs
@@ -58,6 +58,32 @@ impl ExtensionAdapter {
             });
         }
 
+        if source == ExtensionSource::AgentSkills {
+            let skill_path = if path.is_dir() {
+                path.join("SKILL.md")
+            } else {
+                path.to_path_buf()
+            };
+            if !skill_path.is_file() {
+                warnings.push(format!("SKILL.md not found at {:?}", skill_path));
+                return Ok(ImportResult {
+                    source,
+                    capability: ImportCapability::Unsupported,
+                    canonical: None,
+                    warnings,
+                    errors,
+                });
+            }
+            let (_, canonical) = crate::AgentSkillsAdapter::import(&skill_path).await?;
+            return Ok(ImportResult {
+                source,
+                capability: ImportCapability::Supported,
+                canonical: Some(canonical),
+                warnings,
+                errors,
+            });
+        }
+
         // Attempt import (placeholder for actual implementation)
         warnings.push(format!(
             "Import from {:?} at {:?} not yet implemented",

--- a/crates/impetus-core/src/extension_compat.rs
+++ b/crates/impetus-core/src/extension_compat.rs
@@ -213,15 +213,15 @@ impl CompatibilityMatrix {
     /// Get compatibility matrix for Agent Skills
     pub fn agent_skills() -> Self {
         let mut capabilities = HashMap::new();
-        capabilities.insert("instructions".to_string(), ImportCapability::Unsupported);
+        capabilities.insert("instructions".to_string(), ImportCapability::Supported);
         capabilities.insert("tools".to_string(), ImportCapability::Unsupported);
-        capabilities.insert("triggers".to_string(), ImportCapability::Unsupported);
+        capabilities.insert("triggers".to_string(), ImportCapability::Supported);
         capabilities.insert("profiles".to_string(), ImportCapability::Unsupported);
 
         Self {
             source: ExtensionSource::AgentSkills,
             capabilities,
-            notes: vec!["Requires upstream spec audit before implementation".to_string()],
+            notes: vec!["SKILL.md instruction and trigger import is supported".to_string()],
         }
     }
 

--- a/crates/impetus-core/src/harness_api.rs
+++ b/crates/impetus-core/src/harness_api.rs
@@ -684,7 +684,7 @@ fn runtime_error(error: RuntimeError) -> IpcResponse {
 
 fn gather_subsystem_health(
     store: &Arc<dyn EventStore>,
-    _policy: &PolicyEngine,
+    policy: &PolicyEngine,
     provider_registry: &ProviderRegistry,
     workspace_root: &Path,
 ) -> crate::SubsystemHealth {
@@ -761,15 +761,24 @@ fn gather_subsystem_health(
     // Disk/Runtime health
     let disk_runtime = probe_disk_runtime(workspace_root);
 
-    // Web research capabilities (WEB section)
-    let web_research = SubsystemStatus::unavailable("Web research not yet implemented")
-        .with_details(serde_json::json!({
-            "internet_access": false,
-            "web_fetch": false,
-            "search_backends": [],
-            "browser_provider": false,
-            "note": "Native web research planned in WEB section"
-        }));
+    // Offline-safe web inspection: live backend checks are deliberately not run by doctor.
+    let web_engine = crate::web_research::WebResearchEngine::production(
+        crate::web_research::EgressPolicy::default(),
+    );
+    let web_report = crate::web_research::WebDoctor::inspect(
+        &web_engine,
+        crate::web_research::BrowserServiceStatus::Unavailable,
+    );
+    let web_research = SubsystemStatus::ok("Native web research contract available").with_details(
+        serde_json::json!({
+            "internet_access": policy.scope().allow_network,
+            "web_fetch": true,
+            "search_backends": web_report.search_backends,
+            "browser_provider": web_report.browser,
+            "live_probe_performed": web_report.live_probe_performed,
+            "notes": web_report.notes,
+        }),
+    );
 
     crate::SubsystemHealth {
         event_store,
@@ -1148,7 +1157,7 @@ mod tests {
             target: None,
         };
         let expected_decision = policy.evaluate(&denied_ssh);
-        let store = Arc::new(MemoryEventStore::default());
+        let store: Arc<dyn EventStore> = Arc::new(MemoryEventStore::default());
         let harness = Harness::new(store.clone(), policy.clone());
         let IpcResponse::Session { session_id, .. } = harness.handle(IpcRequest::CreateSession {
             workspace_root: root.clone(),
@@ -1727,5 +1736,21 @@ mod tests {
                 EventPayload::Agent(crate::AgentEvent::Final { .. })
             )
         }));
+    }
+
+    #[test]
+    fn doctor_reports_offline_safe_web_research_contract() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let store: Arc<dyn EventStore> = Arc::new(MemoryEventStore::default());
+        let policy = PolicyEngine::new(SandboxScope::local_workspace(workspace.path()));
+        let health =
+            gather_subsystem_health(&store, &policy, &ProviderRegistry::new(), workspace.path());
+
+        assert!(health.web_research.available);
+        let details = health.web_research.details.expect("web details");
+        assert_eq!(details["internet_access"], false);
+        assert_eq!(details["web_fetch"], true);
+        assert_eq!(details["search_backends"][0]["id"], "bing_html");
+        assert_eq!(details["search_backends"][1]["id"], "duckduckgo");
     }
 }

--- a/crates/impetus-core/src/lib.rs
+++ b/crates/impetus-core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod storage;
 pub mod supervisor;
 pub mod tool_orchestrator;
 pub mod tools;
+pub mod web_research;
 
 pub use agent_loop::{AgentLoop, AgentLoopError, ToolCall};
 pub use agent_skills_adapter::AgentSkillsAdapter;

--- a/crates/impetus-core/src/tool_orchestrator.rs
+++ b/crates/impetus-core/src/tool_orchestrator.rs
@@ -59,6 +59,7 @@ pub struct ToolOrchestrator {
     policy: PolicyEngine,
     workspace_root: PathBuf,
     artifact_root: PathBuf,
+    web_research: Option<Arc<dyn crate::web_research::WebResearchService>>,
 }
 
 impl ToolOrchestrator {
@@ -75,7 +76,17 @@ impl ToolOrchestrator {
             policy,
             workspace_root,
             artifact_root,
+            web_research: None,
         }
+    }
+
+    /// Attach the daemon-owned semantic web service. Provider details stay outside the agent loop.
+    pub fn with_web_research(
+        mut self,
+        service: Arc<dyn crate::web_research::WebResearchService>,
+    ) -> Self {
+        self.web_research = Some(service);
+        self
     }
 
     /// Process a batch of tool calls from the model.
@@ -117,13 +128,15 @@ impl ToolOrchestrator {
                 let orchestrator_policy = self.policy.clone();
                 let orchestrator_workspace = self.workspace_root.clone();
                 let orchestrator_artifact = self.artifact_root.clone();
+                let web_research = self.web_research.clone();
 
                 let handle = tokio::spawn(async move {
                     let orchestrator = ToolOrchestrator::with_artifact_root(
                         orchestrator_policy,
                         orchestrator_workspace,
                         orchestrator_artifact,
-                    );
+                    )
+                    .with_optional_web_research(web_research);
                     orchestrator.process_single_tool(tool_call, &runtime).await
                 });
                 handles.push(handle);
@@ -144,6 +157,14 @@ impl ToolOrchestrator {
         }
 
         Ok(observations)
+    }
+
+    fn with_optional_web_research(
+        mut self,
+        service: Option<Arc<dyn crate::web_research::WebResearchService>>,
+    ) -> Self {
+        self.web_research = service;
+        self
     }
 
     async fn process_single_tool(
@@ -216,6 +237,64 @@ impl ToolOrchestrator {
             );
         }
 
+        if matches!(tool_call.name.as_str(), "web_search" | "web_fetch") {
+            let status = match runtime.request_action_with_capability_version(action, Some(1)) {
+                Ok(status) => status,
+                Err(RuntimeError::Denied(reason)) => {
+                    return Self::record_observation(
+                        runtime,
+                        tool_call,
+                        arguments_summary,
+                        ToolOutcomeStatus::Denied,
+                        String::new(),
+                        None,
+                        Some(reason),
+                    );
+                }
+                Err(error) => {
+                    return Self::record_observation(
+                        runtime,
+                        tool_call,
+                        arguments_summary,
+                        ToolOutcomeStatus::Error,
+                        String::new(),
+                        None,
+                        Some(error.to_string()),
+                    );
+                }
+            };
+            if matches!(status, crate::RuntimeStatus::AwaitingApproval) {
+                if let Some(approval_id) = runtime.events().ok().and_then(|events| {
+                    events.iter().rev().find_map(|event| match &event.payload {
+                        crate::EventPayload::Approval(crate::ApprovalEvent::Requested {
+                            request,
+                        }) => Some(request.id),
+                        _ => None,
+                    })
+                }) {
+                    let _ = runtime.record_deferred_tool(
+                        approval_id,
+                        tool_call.id.clone(),
+                        tool_call.name.clone(),
+                        tool_call.arguments.clone(),
+                    );
+                }
+                return Self::record_observation(
+                    runtime,
+                    tool_call,
+                    arguments_summary,
+                    ToolOutcomeStatus::ApprovalRequired,
+                    String::new(),
+                    None,
+                    Some("awaiting user approval".into()),
+                );
+            }
+
+            return self
+                .execute_web_tool(runtime, tool_call, arguments_summary)
+                .await;
+        }
+
         match self.execute_read_only(&tool_call) {
             Ok(ToolOutcome::Allowed { result }) => Self::record_observation(
                 runtime,
@@ -254,6 +333,7 @@ impl ToolOrchestrator {
         // Map tool names to ActionKind
         let kind = match tool_call.name.as_str() {
             "list_files" | "read_file" | "search" => ActionKind::ReadFile,
+            "web_search" | "web_fetch" => ActionKind::NetworkConnect,
             "write_file" | "edit_file" => ActionKind::WriteFile,
             "bash" | "shell" | "exec" => ActionKind::SpawnProcess,
             name => {
@@ -269,6 +349,15 @@ impl ToolOrchestrator {
             .map(|s| s.to_string());
         let target = if kind == ActionKind::SpawnProcess {
             Some(self.workspace_root.display().to_string())
+        } else if tool_call.name == "web_search" {
+            Some("web-search:auto".into())
+        } else if tool_call.name == "web_fetch" {
+            tool_call
+                .arguments
+                .get("url")
+                .and_then(serde_json::Value::as_str)
+                .and_then(|url| reqwest::Url::parse(url).ok())
+                .and_then(|url| url.host_str().map(str::to_owned))
         } else {
             target
         };
@@ -324,6 +413,102 @@ impl ToolOrchestrator {
                 tool: tool_call.name.clone(),
                 reason: error.to_string(),
             })
+    }
+
+    async fn execute_web_tool(
+        &self,
+        runtime: &Arc<AgentRuntime>,
+        tool_call: crate::ToolCall,
+        arguments_summary: String,
+    ) -> ToolObservation {
+        let action = match self.normalize_tool_call(&tool_call) {
+            Ok(action) => action,
+            Err(error) => {
+                return Self::record_observation(
+                    runtime,
+                    tool_call,
+                    arguments_summary,
+                    ToolOutcomeStatus::Error,
+                    String::new(),
+                    None,
+                    Some(error.to_string()),
+                );
+            }
+        };
+        let effect = crate::NormalizedEffect::network_connect(
+            ActionOrigin::Agent,
+            action.summary,
+            action.target.unwrap_or_else(|| "web:invalid-target".into()),
+        );
+        let seam = EffectSeam::with_sandbox(
+            self.policy.clone(),
+            Sandbox::Provisioned {
+                scope: self.policy.scope().clone(),
+            },
+        );
+        match seam.decide(&effect) {
+            crate::EffectDecision::Allow => {}
+            crate::EffectDecision::NeedsApproval { reason } => {
+                return Self::record_observation(
+                    runtime,
+                    tool_call,
+                    arguments_summary,
+                    ToolOutcomeStatus::ApprovalRequired,
+                    String::new(),
+                    None,
+                    Some(reason),
+                );
+            }
+            crate::EffectDecision::Deny { reason } => {
+                return Self::record_observation(
+                    runtime,
+                    tool_call,
+                    arguments_summary,
+                    ToolOutcomeStatus::Denied,
+                    String::new(),
+                    None,
+                    Some(reason),
+                );
+            }
+        }
+        let Some(service) = &self.web_research else {
+            return Self::record_observation(
+                runtime,
+                tool_call,
+                arguments_summary,
+                ToolOutcomeStatus::Error,
+                String::new(),
+                None,
+                Some("web research service is unavailable".into()),
+            );
+        };
+        let artifacts = match DurableArtifactStore::open(&self.artifact_root) {
+            Ok(artifacts) => artifacts,
+            Err(error) => {
+                return Self::record_observation(
+                    runtime,
+                    tool_call,
+                    arguments_summary,
+                    ToolOutcomeStatus::Error,
+                    String::new(),
+                    None,
+                    Some(format!("cannot open artifact store: {error}")),
+                );
+            }
+        };
+        let observation =
+            crate::web_research::execute_web_tool(service.as_ref(), &tool_call, &artifacts)
+                .await
+                .expect("web tool names are checked before dispatch");
+        Self::record_observation(
+            runtime,
+            tool_call,
+            observation.arguments_summary,
+            observation.outcome,
+            observation.preview,
+            observation.artifact,
+            observation.error,
+        )
     }
 
     fn record_observation(
@@ -571,6 +756,71 @@ fn contains_sensitive_value(arguments: &serde_json::Value) -> bool {
 mod tests {
     use super::*;
     use crate::{MemoryEventStore, SandboxScope};
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingWebService(AtomicUsize);
+
+    #[async_trait]
+    impl crate::web_research::WebSearchService for CountingWebService {
+        async fn search(
+            &self,
+            _request: crate::web_research::SearchRequest,
+        ) -> Result<crate::web_research::SearchResponse, crate::web_research::WebError> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            unreachable!("network-disabled policy must stop web search before execution")
+        }
+    }
+
+    #[async_trait]
+    impl crate::web_research::WebFetchService for CountingWebService {
+        async fn fetch(
+            &self,
+            _request: crate::web_research::FetchRequest,
+        ) -> Result<crate::web_research::FetchedPage, crate::web_research::WebError> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            unreachable!("network-disabled policy must stop web fetch before execution")
+        }
+    }
+
+    #[tokio::test]
+    async fn web_search_is_denied_before_service_execution_when_network_is_disabled() {
+        let workspace = tempfile::tempdir().expect("temp workspace");
+        let policy = PolicyEngine::new(SandboxScope::local_workspace(workspace.path()));
+        let runtime = Arc::new(AgentRuntime::new(
+            Arc::new(MemoryEventStore::default()),
+            policy.clone(),
+        ));
+        let service = Arc::new(CountingWebService(AtomicUsize::new(0)));
+        let orchestrator = ToolOrchestrator::new(policy, workspace.path().to_path_buf())
+            .with_web_research(service.clone());
+
+        let observations = orchestrator
+            .process_tool_calls(
+                Uuid::new_v4(),
+                vec![crate::ToolCall {
+                    id: "web-call".into(),
+                    name: "web_search".into(),
+                    arguments: serde_json::json!({"query": "private research"}),
+                }],
+                &runtime,
+            )
+            .await
+            .expect("tool orchestration");
+
+        assert_eq!(observations[0].outcome, ToolOutcomeStatus::Denied);
+        assert_eq!(service.0.load(Ordering::SeqCst), 0);
+        assert!(runtime.events().expect("events").iter().any(|event| {
+            matches!(
+                &event.payload,
+                crate::EventPayload::Tool(crate::ToolEvent::Observed {
+                    tool_name,
+                    outcome: ToolOutcomeStatus::Denied,
+                    ..
+                }) if tool_name == "web_search"
+            )
+        }));
+    }
 
     #[test]
     fn normalize_read_file_tool() {

--- a/crates/impetus-core/src/web_research/bing.rs
+++ b/crates/impetus-core/src/web_research/bing.rs
@@ -1,0 +1,213 @@
+use std::{collections::HashSet, sync::Arc, time::Instant};
+
+use async_trait::async_trait;
+use reqwest::Url;
+use scraper::{ElementRef, Html, Selector};
+
+use super::{
+    SafeSearch, SearchAttempt, SearchHit, SearchRequest, SearchResponse, SecureHttpClient,
+    WebError, WebErrorKind, WebOutcome,
+    html::normalize_whitespace,
+    service::{SearchBackend, citation_id},
+};
+
+const BING_ENDPOINT: &str = "https://www.bing.com/search";
+const SEARCH_BODY_LIMIT: usize = 2 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct BingHtmlSearchBackend {
+    http: Arc<SecureHttpClient>,
+}
+
+impl BingHtmlSearchBackend {
+    pub fn new(http: Arc<SecureHttpClient>) -> Self {
+        Self { http }
+    }
+
+    fn request_url(&self, request: &SearchRequest) -> Result<Url, WebError> {
+        let mut url = Url::parse(BING_ENDPOINT).map_err(|error| {
+            WebError::new(
+                WebErrorKind::Configuration,
+                format!("invalid Bing HTML endpoint: {error}"),
+            )
+        })?;
+        {
+            let mut pairs = url.query_pairs_mut();
+            pairs.append_pair("q", request.query.trim());
+            if let Some(locale) = request
+                .locale
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                pairs.append_pair("mkt", locale);
+            }
+            let safe = match request.safe_search {
+                SafeSearch::Off => "off",
+                SafeSearch::Moderate => "moderate",
+                SafeSearch::Strict => "strict",
+            };
+            pairs.append_pair("adlt", safe);
+        }
+        Ok(url)
+    }
+}
+
+#[async_trait]
+impl SearchBackend for BingHtmlSearchBackend {
+    fn id(&self) -> &str {
+        "bing_html"
+    }
+
+    async fn search(&self, request: &SearchRequest) -> Result<SearchResponse, WebError> {
+        let started = Instant::now();
+        let url = self.request_url(request)?;
+        let response = self.http.get(url.as_str(), SEARCH_BODY_LIMIT).await?;
+        if !response.status.is_success() {
+            return Err(WebError::new(
+                WebErrorKind::HttpStatus,
+                format!("Bing HTML returned HTTP {}", response.status.as_u16()),
+            )
+            .with_url(response.final_url));
+        }
+
+        let hits = parse_bing_results(&response.body, request.normalized_limit());
+        if hits.is_empty() && detect_anti_bot_page(&response.body) {
+            return Err(WebError::new(
+                WebErrorKind::BackendUnavailable,
+                "Bing returned an anti-bot/challenge page instead of search results",
+            )
+            .with_url(response.final_url));
+        }
+        let outcome = if hits.is_empty() {
+            WebOutcome::NoResults
+        } else {
+            WebOutcome::Success
+        };
+        Ok(SearchResponse {
+            outcome,
+            backend: self.id().into(),
+            query: request.query.clone(),
+            hits,
+            attempts: vec![SearchAttempt {
+                backend: self.id().into(),
+                endpoint: BING_ENDPOINT.into(),
+                outcome,
+                detail: None,
+            }],
+            elapsed_ms: elapsed_ms(started),
+        })
+    }
+}
+
+fn parse_bing_results(body: &[u8], max_results: usize) -> Vec<SearchHit> {
+    let source = String::from_utf8_lossy(body);
+    let document = Html::parse_document(&source);
+    let block_selector = Selector::parse("li.b_algo").expect("static selector is valid");
+    let link_selector = Selector::parse("h2 a").expect("static selector is valid");
+    let snippet_selector = Selector::parse(".b_caption p").expect("static selector is valid");
+    let mut hits = Vec::new();
+    let mut seen = HashSet::new();
+
+    for block in document.select(&block_selector) {
+        let Some(link) = block.select(&link_selector).next() else {
+            continue;
+        };
+        let Some(url) = clean_result_url(&link) else {
+            continue;
+        };
+        if !seen.insert(url.clone()) {
+            continue;
+        }
+        let title = normalize_whitespace(&link.text().collect::<Vec<_>>().join(" "));
+        if title.is_empty() {
+            continue;
+        }
+        let snippet = block
+            .select(&snippet_selector)
+            .next()
+            .map(|element| normalize_whitespace(&element.text().collect::<Vec<_>>().join(" ")))
+            .unwrap_or_default();
+        hits.push(SearchHit {
+            rank: hits.len() + 1,
+            title,
+            citation_id: citation_id("search", &url),
+            url,
+            snippet,
+            backend: "bing_html".into(),
+        });
+        if hits.len() >= max_results {
+            break;
+        }
+    }
+    hits
+}
+
+fn clean_result_url(link: &ElementRef<'_>) -> Option<String> {
+    let href = link.value().attr("href")?;
+    let url = Url::parse(href).ok()?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return None;
+    }
+    if url
+        .host_str()
+        .is_some_and(|host| host == "bing.com" || host.ends_with(".bing.com"))
+    {
+        return None;
+    }
+    Some(url.to_string())
+}
+
+fn detect_anti_bot_page(body: &[u8]) -> bool {
+    let source = String::from_utf8_lossy(body).to_ascii_lowercase();
+    [
+        "captcha",
+        "g-recaptcha",
+        "are you a robot",
+        "unusual traffic",
+        "verify you are human",
+        "challenge-platform",
+        "cf-challenge",
+    ]
+    .iter()
+    .any(|marker| source.contains(marker))
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bing_html_results() {
+        let html = br#"
+            <ol id="b_results">
+              <li class="b_algo">
+                <h2><a href="https://example.com/a">First result</a></h2>
+                <div class="b_caption"><p>Useful snippet.</p></div>
+              </li>
+              <li class="b_algo">
+                <h2><a href="https://example.org/b">Second result</a></h2>
+              </li>
+            </ol>
+        "#;
+        let hits = parse_bing_results(html, 10);
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].title, "First result");
+        assert_eq!(hits[0].snippet, "Useful snippet.");
+        assert_eq!(hits[1].rank, 2);
+    }
+
+    #[test]
+    fn ignores_bing_navigation_links() {
+        let html = br#"
+            <li class="b_algo">
+              <h2><a href="https://www.bing.com/search?q=other">Navigation</a></h2>
+            </li>
+        "#;
+        assert!(parse_bing_results(html, 10).is_empty());
+    }
+}

--- a/crates/impetus-core/src/web_research/browser.rs
+++ b/crates/impetus-core/src/web_research/browser.rs
@@ -1,0 +1,89 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use super::{FetchRequest, FetchedPage, WebError};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BrowserCapability {
+    Navigate,
+    Snapshot,
+    RenderedReadableText,
+    RenderedLinks,
+    Screenshot,
+    Click,
+    Type,
+    Wait,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BrowserProviderDescriptor {
+    pub provider_id: String,
+    pub provider_version: Option<String>,
+    pub protocol_version: String,
+    pub browser_families: Vec<String>,
+    pub capabilities: Vec<BrowserCapability>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "status")]
+pub enum BrowserServiceStatus {
+    Unavailable,
+    Degraded {
+        reason: String,
+    },
+    Misconfigured {
+        reason: String,
+    },
+    Available {
+        provider_id: String,
+        capabilities: Vec<BrowserCapability>,
+    },
+}
+
+/// Optional Tier-2 backend contract. Concrete providers should be registered and lifecycle-managed
+/// by Module Runtime so discovery, health, compatibility and isolation stay out of Agent Loop.
+///
+/// This intentionally models only the browser surface needed by web research. Rich interactive
+/// operations (click/type/screenshot/session/page refs) can be added as capability-negotiated
+/// provider methods without making Chromium/Playwright/Node mandatory core dependencies.
+#[async_trait]
+pub trait BrowserProvider: Send + Sync {
+    fn browser_descriptor(&self) -> BrowserProviderDescriptor;
+    async fn browser_status(&self) -> BrowserServiceStatus;
+    async fn fetch_rendered(&self, request: FetchRequest) -> Result<FetchedPage, WebError>;
+}
+
+#[async_trait]
+pub trait BrowserService: Send + Sync {
+    async fn status(&self) -> BrowserServiceStatus;
+    async fn fetch_rendered(&self, request: FetchRequest) -> Result<FetchedPage, WebError>;
+}
+
+/// Thin facade used by web research. Agent Loop sees `BrowserService`, never a concrete bridge.
+pub struct ProviderBackedBrowserService {
+    provider: Arc<dyn BrowserProvider>,
+}
+
+impl ProviderBackedBrowserService {
+    pub fn new(provider: Arc<dyn BrowserProvider>) -> Self {
+        Self { provider }
+    }
+
+    pub fn descriptor(&self) -> BrowserProviderDescriptor {
+        self.provider.browser_descriptor()
+    }
+}
+
+#[async_trait]
+impl BrowserService for ProviderBackedBrowserService {
+    async fn status(&self) -> BrowserServiceStatus {
+        self.provider.browser_status().await
+    }
+
+    async fn fetch_rendered(&self, request: FetchRequest) -> Result<FetchedPage, WebError> {
+        self.provider.fetch_rendered(request).await
+    }
+}

--- a/crates/impetus-core/src/web_research/doctor.rs
+++ b/crates/impetus-core/src/web_research/doctor.rs
@@ -1,0 +1,225 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    BrowserServiceStatus, SearchRequest, WebOutcome, WebResearchEngine, WebResearchService,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "status")]
+pub enum BackendDoctorStatus {
+    BuiltIn,
+    Configured,
+    Reachable,
+    Unavailable { reason: String },
+    Misconfigured { reason: String },
+    Failed { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchBackendDoctorEntry {
+    pub id: String,
+    pub status: BackendDoctorStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebDoctorReport {
+    pub search_backends: Vec<SearchBackendDoctorEntry>,
+    pub browser: BrowserServiceStatus,
+    pub live_probe_performed: bool,
+    pub notes: Vec<String>,
+}
+
+pub struct WebDoctor;
+
+impl WebDoctor {
+    /// Offline-safe inspection. No network requests and no secret values are included.
+    pub fn inspect(engine: &WebResearchEngine, browser: BrowserServiceStatus) -> WebDoctorReport {
+        let mut search_backends = engine
+            .builtin_backend_ids()
+            .map(|id| SearchBackendDoctorEntry {
+                id: id.to_string(),
+                status: BackendDoctorStatus::BuiltIn,
+            })
+            .collect::<Vec<_>>();
+        search_backends.extend(
+            engine
+                .external_backend_ids()
+                .map(|id| SearchBackendDoctorEntry {
+                    id: id.to_string(),
+                    status: BackendDoctorStatus::Configured,
+                }),
+        );
+
+        WebDoctorReport {
+            search_backends,
+            browser,
+            live_probe_performed: false,
+            notes: vec![
+                "offline inspection only; run the explicit live probe to test outbound search"
+                    .into(),
+            ],
+        }
+    }
+
+    /// Preferred live probe when the concrete engine is available: probe every configured
+    /// backend once instead of stopping when the normal fallback chain finds a working result.
+    pub async fn probe_engine(engine: &WebResearchEngine) -> WebDoctorReport {
+        let mut report = WebDoctorReport {
+            search_backends: Vec::new(),
+            browser: BrowserServiceStatus::Unavailable,
+            live_probe_performed: true,
+            notes: Vec::new(),
+        };
+        let primary = engine.default_backend_id().to_string();
+        let mut primary_healthy = false;
+        let mut fallback_healthy = false;
+
+        for (id, result) in engine
+            .probe_search_backends(SearchRequest::new("Example Domain"))
+            .await
+        {
+            let status = match result {
+                Ok(response) => match response.outcome {
+                    WebOutcome::Success | WebOutcome::NoResults => {
+                        if id == primary {
+                            primary_healthy = true;
+                        } else {
+                            fallback_healthy = true;
+                        }
+                        BackendDoctorStatus::Reachable
+                    }
+                    WebOutcome::Blocked => BackendDoctorStatus::Unavailable {
+                        reason: response
+                            .attempts
+                            .last()
+                            .and_then(|attempt| attempt.detail.clone())
+                            .unwrap_or_else(|| "outbound search was blocked".into()),
+                    },
+                    WebOutcome::Failed => BackendDoctorStatus::Failed {
+                        reason: response
+                            .attempts
+                            .last()
+                            .and_then(|attempt| attempt.detail.clone())
+                            .unwrap_or_else(|| "search backend probe failed".into()),
+                    },
+                },
+                Err(error) => {
+                    if error.blocked() {
+                        BackendDoctorStatus::Unavailable {
+                            reason: error.message,
+                        }
+                    } else {
+                        BackendDoctorStatus::Failed {
+                            reason: error.message,
+                        }
+                    }
+                }
+            };
+            report
+                .search_backends
+                .push(SearchBackendDoctorEntry { id, status });
+        }
+
+        if !primary_healthy && fallback_healthy {
+            report.notes.push(
+                "DEGRADED - primary search backend is unavailable, but a fallback is reachable"
+                    .into(),
+            );
+        }
+        report
+    }
+
+    /// Explicit live probe for `impetus doctor --probe-network` style wiring.
+    /// Use this generic contract path only when the concrete engine is unavailable; unlike
+    /// `probe_engine`, it observes the normal fallback chain and may not contact every backend.
+    pub async fn probe_search(service: &dyn WebResearchService) -> WebDoctorReport {
+        let mut report = WebDoctorReport {
+            search_backends: Vec::new(),
+            browser: BrowserServiceStatus::Unavailable,
+            live_probe_performed: true,
+            notes: Vec::new(),
+        };
+
+        let request = SearchRequest::new("Example Domain");
+        match service.search(request).await {
+            Ok(response) => {
+                let mut by_backend: BTreeMap<String, BackendDoctorStatus> = BTreeMap::new();
+                let mut fallback_used = false;
+                for attempt in &response.attempts {
+                    let status = match attempt.outcome {
+                        WebOutcome::Success | WebOutcome::NoResults => {
+                            BackendDoctorStatus::Reachable
+                        }
+                        WebOutcome::Blocked => BackendDoctorStatus::Unavailable {
+                            reason: attempt.detail.clone().unwrap_or_else(|| {
+                                "outbound search was blocked by policy or network egress".into()
+                            }),
+                        },
+                        WebOutcome::Failed => BackendDoctorStatus::Failed {
+                            reason: attempt
+                                .detail
+                                .clone()
+                                .unwrap_or_else(|| "search backend probe failed".into()),
+                        },
+                    };
+                    let entry = by_backend
+                        .entry(attempt.backend.clone())
+                        .or_insert_with(|| status.clone());
+                    if matches!(status, BackendDoctorStatus::Reachable) {
+                        *entry = BackendDoctorStatus::Reachable;
+                    }
+                    if attempt.backend != response.backend
+                        && !matches!(attempt.outcome, WebOutcome::Success | WebOutcome::NoResults)
+                    {
+                        fallback_used = true;
+                    }
+                }
+                if by_backend.is_empty() {
+                    by_backend.insert(
+                        response.backend.clone(),
+                        match response.outcome {
+                            WebOutcome::Success | WebOutcome::NoResults => {
+                                BackendDoctorStatus::Reachable
+                            }
+                            WebOutcome::Blocked => BackendDoctorStatus::Unavailable {
+                                reason: "outbound search was blocked by policy or network egress"
+                                    .into(),
+                            },
+                            WebOutcome::Failed => BackendDoctorStatus::Failed {
+                                reason: "search backend probe failed".into(),
+                            },
+                        },
+                    );
+                }
+                report.search_backends.extend(
+                    by_backend
+                        .into_iter()
+                        .map(|(id, status)| SearchBackendDoctorEntry { id, status }),
+                );
+                if fallback_used && response.outcome == WebOutcome::Success {
+                    report.notes.push(
+                        "DEGRADED - primary search path failed, but a fallback backend is available"
+                            .into(),
+                    );
+                }
+            }
+            Err(error) => {
+                report.search_backends.push(SearchBackendDoctorEntry {
+                    id: "web_search".into(),
+                    status: if error.blocked() {
+                        BackendDoctorStatus::Unavailable {
+                            reason: error.message,
+                        }
+                    } else {
+                        BackendDoctorStatus::Failed {
+                            reason: error.message,
+                        }
+                    },
+                });
+            }
+        }
+        report
+    }
+}

--- a/crates/impetus-core/src/web_research/duckduckgo.rs
+++ b/crates/impetus-core/src/web_research/duckduckgo.rs
@@ -1,0 +1,431 @@
+use std::{collections::HashSet, sync::Arc, time::Instant};
+
+use async_trait::async_trait;
+use reqwest::Url;
+use scraper::{ElementRef, Html, Selector};
+
+use super::{
+    SafeSearch, SearchAttempt, SearchHit, SearchRequest, SearchResponse, SecureHttpClient,
+    WebError, WebErrorKind, WebOutcome,
+    html::normalize_whitespace,
+    service::{SearchBackend, citation_id},
+};
+
+const HTML_ENDPOINT: &str = "https://html.duckduckgo.com/html/";
+const LITE_ENDPOINT: &str = "https://lite.duckduckgo.com/lite/";
+const SEARCH_BODY_LIMIT: usize = 2 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct DuckDuckGoSearchBackend {
+    http: Arc<SecureHttpClient>,
+}
+
+impl DuckDuckGoSearchBackend {
+    pub fn new(http: Arc<SecureHttpClient>) -> Self {
+        Self { http }
+    }
+
+    async fn attempt(
+        &self,
+        endpoint: &str,
+        request: &SearchRequest,
+        parser: fn(&[u8], usize) -> Vec<SearchHit>,
+    ) -> Result<(Vec<SearchHit>, SearchAttempt), WebError> {
+        let url = Url::parse(endpoint).map_err(|error| {
+            WebError::new(
+                WebErrorKind::Configuration,
+                format!("invalid DuckDuckGo endpoint: {error}"),
+            )
+        })?;
+        let response = self
+            .http
+            .post_form(url.as_str(), build_search_form(request), SEARCH_BODY_LIMIT)
+            .await?;
+        if !response.status.is_success() {
+            return Err(WebError::new(
+                WebErrorKind::HttpStatus,
+                format!(
+                    "DuckDuckGo endpoint returned HTTP {}",
+                    response.status.as_u16()
+                ),
+            )
+            .with_url(response.final_url));
+        }
+        let hits = parser(&response.body, request.normalized_limit());
+        if hits.is_empty() && detect_anti_bot_page(&response.body) {
+            return Err(WebError::new(
+                WebErrorKind::BackendUnavailable,
+                "DuckDuckGo returned an anti-bot/challenge page instead of search results",
+            )
+            .with_url(response.final_url));
+        }
+        let outcome = if hits.is_empty() {
+            WebOutcome::NoResults
+        } else {
+            WebOutcome::Success
+        };
+        Ok((
+            hits,
+            SearchAttempt {
+                backend: self.id().to_string(),
+                endpoint: endpoint.to_string(),
+                outcome,
+                detail: None,
+            },
+        ))
+    }
+}
+
+#[async_trait]
+impl SearchBackend for DuckDuckGoSearchBackend {
+    fn id(&self) -> &str {
+        "duckduckgo"
+    }
+
+    async fn search(&self, request: &SearchRequest) -> Result<SearchResponse, WebError> {
+        let started = Instant::now();
+        let mut attempts = Vec::new();
+        let mut last_error = None;
+
+        for (endpoint, parser) in [
+            (
+                HTML_ENDPOINT,
+                parse_html_results as fn(&[u8], usize) -> Vec<SearchHit>,
+            ),
+            (
+                LITE_ENDPOINT,
+                parse_lite_results as fn(&[u8], usize) -> Vec<SearchHit>,
+            ),
+        ] {
+            match self.attempt(endpoint, request, parser).await {
+                Ok((hits, attempt)) => {
+                    let outcome = attempt.outcome;
+                    attempts.push(attempt);
+                    if !hits.is_empty() {
+                        return Ok(SearchResponse {
+                            outcome: WebOutcome::Success,
+                            backend: self.id().to_string(),
+                            query: request.query.clone(),
+                            hits,
+                            attempts,
+                            elapsed_ms: elapsed_ms(started),
+                        });
+                    }
+                    if outcome == WebOutcome::Blocked {
+                        break;
+                    }
+                }
+                Err(error) => {
+                    attempts.push(SearchAttempt {
+                        backend: self.id().to_string(),
+                        endpoint: endpoint.to_string(),
+                        outcome: if error.blocked() {
+                            WebOutcome::Blocked
+                        } else {
+                            WebOutcome::Failed
+                        },
+                        detail: Some(error.message.clone()),
+                    });
+                    let blocked = error.blocked();
+                    last_error = Some(error);
+                    if blocked {
+                        break;
+                    }
+                }
+            }
+        }
+
+        let outcome = if attempts
+            .iter()
+            .any(|attempt| attempt.outcome == WebOutcome::Blocked)
+        {
+            WebOutcome::Blocked
+        } else if attempts
+            .iter()
+            .all(|attempt| attempt.outcome == WebOutcome::NoResults)
+        {
+            WebOutcome::NoResults
+        } else {
+            WebOutcome::Failed
+        };
+        let mut response = SearchResponse {
+            outcome,
+            backend: self.id().to_string(),
+            query: request.query.clone(),
+            hits: Vec::new(),
+            attempts,
+            elapsed_ms: elapsed_ms(started),
+        };
+
+        // Transport failures are represented as a stable failed response so the engine can
+        // deterministically try an explicitly configured external fallback. Keep the error
+        // detail in attempts rather than triggering another retry loop in Agent Loop.
+        if response.attempts.is_empty()
+            && let Some(error) = last_error
+        {
+            response.attempts.push(SearchAttempt {
+                backend: self.id().to_string(),
+                endpoint: "duckduckgo".into(),
+                outcome: WebOutcome::Failed,
+                detail: Some(error.message),
+            });
+        }
+        Ok(response)
+    }
+}
+
+fn build_search_form(request: &SearchRequest) -> Vec<(String, String)> {
+    let mut form = vec![("q".into(), request.query.trim().into())];
+    if let Some(locale) = request
+        .locale
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        form.push(("kl".into(), locale.into()));
+    }
+    match request.safe_search {
+        SafeSearch::Strict => form.push(("kp".into(), "1".into())),
+        SafeSearch::Moderate => form.push(("kp".into(), "-1".into())),
+        SafeSearch::Off => form.push(("kp".into(), "-2".into())),
+    }
+    form
+}
+
+fn detect_anti_bot_page(body: &[u8]) -> bool {
+    let source = String::from_utf8_lossy(body).to_ascii_lowercase();
+    [
+        "anomaly-modal",
+        "anomaly.js",
+        "captcha",
+        "g-recaptcha",
+        "are you a robot",
+        "unusual traffic",
+        "verify you are human",
+        "challenge-platform",
+        "cf-challenge",
+    ]
+    .iter()
+    .any(|marker| source.contains(marker))
+}
+
+fn parse_html_results(body: &[u8], max_results: usize) -> Vec<SearchHit> {
+    let source = String::from_utf8_lossy(body);
+    let document = Html::parse_document(&source);
+    let result_selector = Selector::parse(".result").expect("static selector is valid");
+    let link_selector = Selector::parse("a.result__a").expect("static selector is valid");
+    let snippet_selector = Selector::parse(".result__snippet").expect("static selector is valid");
+    let mut hits = Vec::new();
+    let mut seen = HashSet::new();
+
+    for result in document.select(&result_selector) {
+        let Some(link) = result.select(&link_selector).next() else {
+            continue;
+        };
+        let snippet = result.select(&snippet_selector).next();
+        let Some(hit) = hit_from_elements(&link, snippet.as_ref(), hits.len() + 1) else {
+            continue;
+        };
+        if !seen.insert(hit.url.clone()) {
+            continue;
+        }
+        hits.push(hit);
+        if hits.len() >= max_results {
+            break;
+        }
+    }
+    hits
+}
+
+fn parse_lite_results(body: &[u8], max_results: usize) -> Vec<SearchHit> {
+    let source = String::from_utf8_lossy(body);
+    let document = Html::parse_document(&source);
+    let link_selector = Selector::parse("a.result-link").expect("static selector is valid");
+    let snippet_selector = Selector::parse("td.result-snippet").expect("static selector is valid");
+    let snippets: Vec<_> = document.select(&snippet_selector).collect();
+    let mut hits = Vec::new();
+    let mut seen = HashSet::new();
+
+    for (index, link) in document.select(&link_selector).enumerate() {
+        let Some(hit) = hit_from_elements(&link, snippets.get(index), hits.len() + 1) else {
+            continue;
+        };
+        if !seen.insert(hit.url.clone()) {
+            continue;
+        }
+        hits.push(hit);
+        if hits.len() >= max_results {
+            break;
+        }
+    }
+    hits
+}
+
+fn hit_from_elements(
+    link: &ElementRef<'_>,
+    snippet: Option<&ElementRef<'_>>,
+    rank: usize,
+) -> Option<SearchHit> {
+    let href = link.value().attr("href")?;
+    let url = unwrap_ddg_redirect(href)?;
+    let title = normalize_whitespace(&link.text().collect::<Vec<_>>().join(" "));
+    if title.is_empty() {
+        return None;
+    }
+    let snippet = snippet
+        .map(|element| normalize_whitespace(&element.text().collect::<Vec<_>>().join(" ")))
+        .unwrap_or_default();
+    Some(SearchHit {
+        rank,
+        title,
+        citation_id: citation_id("search", &url),
+        url,
+        snippet,
+        backend: "duckduckgo".into(),
+    })
+}
+
+fn unwrap_ddg_redirect(href: &str) -> Option<String> {
+    let parsed = if href.starts_with("//") {
+        Url::parse(&format!("https:{href}")).ok()?
+    } else if href.starts_with('/') {
+        Url::parse("https://duckduckgo.com").ok()?.join(href).ok()?
+    } else {
+        Url::parse(href).ok()?
+    };
+
+    let target = if parsed
+        .host_str()
+        .is_some_and(|host| host == "duckduckgo.com" || host.ends_with(".duckduckgo.com"))
+        && parsed.path().starts_with("/l/")
+    {
+        parsed
+            .query_pairs()
+            .find(|(key, _)| key == "uddg")
+            .map(|(_, value)| value.into_owned())?
+    } else {
+        parsed.to_string()
+    };
+
+    let target = Url::parse(&target).ok()?;
+    if !matches!(target.scheme(), "http" | "https") {
+        return None;
+    }
+    Some(target.to_string())
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+
+    #[test]
+    fn maps_official_duckduckgo_safe_search_parameters() {
+        let mut request = SearchRequest::new("rust");
+        request.safe_search = SafeSearch::Strict;
+        assert!(build_search_form(&request).contains(&("kp".into(), "1".into())));
+        request.safe_search = SafeSearch::Moderate;
+        assert!(build_search_form(&request).contains(&("kp".into(), "-1".into())));
+        request.safe_search = SafeSearch::Off;
+        assert!(build_search_form(&request).contains(&("kp".into(), "-2".into())));
+    }
+
+    #[test]
+    fn parses_html_endpoint_fixture() {
+        let html = include_bytes!("../../tests/fixtures/web/ddg_html.html");
+        let hits = parse_html_results(html, 10);
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].title, "Rust Programming Language");
+        assert_eq!(hits[0].url, "https://www.rust-lang.org/");
+        assert_eq!(hits[0].rank, 1);
+        assert_eq!(hits[1].url, "https://doc.rust-lang.org/book/");
+    }
+
+    #[test]
+    fn parses_lite_endpoint_fixture() {
+        let html = include_bytes!("../../tests/fixtures/web/ddg_lite.html");
+        let hits = parse_lite_results(html, 10);
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].title, "Rust Programming Language");
+        assert_eq!(hits[0].snippet, "A language empowering everyone.");
+    }
+
+    #[tokio::test]
+    async fn falls_back_from_html_challenge_to_lite_results() {
+        use crate::web_research::{
+            DnsResolver, EgressPolicy, HttpTransport, PreparedGet, PreparedPostForm,
+            RawHttpResponse,
+        };
+        use reqwest::{StatusCode, header::HeaderMap};
+        use std::{collections::VecDeque, net::SocketAddr, sync::Mutex};
+
+        struct Dns;
+        #[async_trait]
+        impl DnsResolver for Dns {
+            async fn resolve(&self, _host: &str, port: u16) -> Result<Vec<SocketAddr>, WebError> {
+                Ok(vec![SocketAddr::new(
+                    "93.184.216.34".parse().unwrap(),
+                    port,
+                )])
+            }
+        }
+
+        struct Transport(Mutex<VecDeque<RawHttpResponse>>);
+        #[async_trait]
+        impl HttpTransport for Transport {
+            async fn get(&self, _request: PreparedGet) -> Result<RawHttpResponse, WebError> {
+                panic!("DuckDuckGo backend must use form POST");
+            }
+            async fn post_form(
+                &self,
+                _request: PreparedPostForm,
+            ) -> Result<RawHttpResponse, WebError> {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .pop_front()
+                    .ok_or_else(|| WebError::new(WebErrorKind::Transport, "missing response"))
+            }
+        }
+
+        let challenge = RawHttpResponse {
+            status: StatusCode::OK,
+            headers: HeaderMap::new(),
+            body: b"<html><div id='anomaly-modal'>verify</div></html>".to_vec(),
+            body_truncated: false,
+        };
+        let lite = RawHttpResponse {
+            status: StatusCode::OK,
+            headers: HeaderMap::new(),
+            body: include_bytes!("../../tests/fixtures/web/ddg_lite.html").to_vec(),
+            body_truncated: false,
+        };
+        let transport = Arc::new(Transport(Mutex::new(VecDeque::from([challenge, lite]))));
+        let http = Arc::new(SecureHttpClient::new(
+            transport,
+            Arc::new(Dns),
+            EgressPolicy::default(),
+        ));
+        let backend = DuckDuckGoSearchBackend::new(http);
+        let response = backend.search(&SearchRequest::new("rust")).await.unwrap();
+        assert_eq!(response.outcome, WebOutcome::Success);
+        assert_eq!(response.hits.len(), 2);
+        assert_eq!(response.attempts.len(), 2);
+        assert_eq!(response.attempts[0].outcome, WebOutcome::Failed);
+        assert_eq!(response.attempts[1].outcome, WebOutcome::Success);
+    }
+
+    #[test]
+    fn unwraps_redirect_and_rejects_non_http_targets() {
+        let wrapped = "//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fdocs&rut=abc";
+        assert_eq!(
+            unwrap_ddg_redirect(wrapped).as_deref(),
+            Some("https://example.com/docs")
+        );
+        assert!(unwrap_ddg_redirect("javascript:alert(1)").is_none());
+    }
+}

--- a/crates/impetus-core/src/web_research/html.rs
+++ b/crates/impetus-core/src/web_research/html.rs
@@ -1,0 +1,301 @@
+use std::collections::HashSet;
+
+use regex::Regex;
+use reqwest::Url;
+use scraper::{Html, Selector};
+
+use super::{FetchBodyKind, FetchLink, WebError, WebErrorKind};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExtractedPage {
+    pub kind: FetchBodyKind,
+    pub title: Option<String>,
+    pub text: String,
+    pub links: Vec<FetchLink>,
+    pub truncated: bool,
+}
+
+pub(crate) fn extract_body(
+    content_type: Option<&str>,
+    body: &[u8],
+    base_url: &str,
+    max_chars: usize,
+    include_links: bool,
+    allow_binary_metadata: bool,
+) -> Result<ExtractedPage, WebError> {
+    let normalized_type = content_type
+        .unwrap_or("")
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+
+    if is_html_type(&normalized_type) || (normalized_type.is_empty() && looks_like_html(body)) {
+        return extract_html(body, base_url, max_chars, include_links);
+    }
+
+    if is_text_type(&normalized_type) || (normalized_type.is_empty() && looks_like_text(body)) {
+        let text = String::from_utf8_lossy(body);
+        let normalized = normalize_whitespace(&text);
+        let (text, truncated) = truncate_chars(&normalized, max_chars);
+        return Ok(ExtractedPage {
+            kind: FetchBodyKind::Text,
+            title: None,
+            text,
+            links: Vec::new(),
+            truncated,
+        });
+    }
+
+    if allow_binary_metadata {
+        return Ok(ExtractedPage {
+            kind: FetchBodyKind::Binary,
+            title: None,
+            text: String::new(),
+            links: Vec::new(),
+            truncated: false,
+        });
+    }
+
+    Err(WebError::new(
+        WebErrorKind::UnsupportedContentType,
+        format!(
+            "binary/unsupported content type '{}' is not readable text",
+            if normalized_type.is_empty() {
+                "unknown"
+            } else {
+                &normalized_type
+            }
+        ),
+    )
+    .with_url(base_url))
+}
+
+fn extract_html(
+    body: &[u8],
+    base_url: &str,
+    max_chars: usize,
+    include_links: bool,
+) -> Result<ExtractedPage, WebError> {
+    let source = String::from_utf8_lossy(body);
+    let cleaned = strip_non_content_blocks(&source);
+    let document = Html::parse_document(&cleaned);
+
+    let title_selector = Selector::parse("title").expect("static title selector is valid");
+    let title = document
+        .select(&title_selector)
+        .next()
+        .map(|element| normalize_whitespace(&element.text().collect::<Vec<_>>().join(" ")))
+        .filter(|title| !title.is_empty());
+
+    let content_selector =
+        Selector::parse("main, article, body").expect("static readable-content selector is valid");
+    let text = document
+        .select(&content_selector)
+        .next()
+        .map(|element| element.text().collect::<Vec<_>>().join(" "))
+        .unwrap_or_else(|| document.root_element().text().collect::<Vec<_>>().join(" "));
+    let normalized = normalize_whitespace(&text);
+    let (text, truncated) = truncate_chars(&normalized, max_chars);
+
+    let links = if include_links {
+        extract_links(&document, base_url)?
+    } else {
+        Vec::new()
+    };
+
+    Ok(ExtractedPage {
+        kind: FetchBodyKind::Html,
+        title,
+        text,
+        links,
+        truncated,
+    })
+}
+
+fn strip_non_content_blocks(source: &str) -> String {
+    let mut cleaned = source.to_string();
+    if let Ok(comment) = Regex::new(r"(?s)<!--.*?-->") {
+        cleaned = comment.replace_all(&cleaned, " ").into_owned();
+    }
+    for tag in [
+        "script", "style", "noscript", "svg", "iframe", "template", "nav", "aside", "form",
+        "select", "dialog", "canvas",
+    ] {
+        let pattern = format!(r"(?is)<{tag}\b[^>]*>.*?</{tag}\s*>");
+        if let Ok(regex) = Regex::new(&pattern) {
+            cleaned = regex.replace_all(&cleaned, " ").into_owned();
+        }
+    }
+    cleaned
+}
+
+fn extract_links(document: &Html, base_url: &str) -> Result<Vec<FetchLink>, WebError> {
+    let base = Url::parse(base_url).map_err(|error| {
+        WebError::new(
+            WebErrorKind::InvalidUrl,
+            format!("cannot resolve page links against invalid base URL: {error}"),
+        )
+        .with_url(base_url)
+    })?;
+    let selector = Selector::parse("a[href]").expect("static link selector is valid");
+    let mut seen = HashSet::new();
+    let mut links = Vec::new();
+
+    for element in document.select(&selector) {
+        let Some(href) = element.value().attr("href") else {
+            continue;
+        };
+        let Ok(url) = base.join(href) else {
+            continue;
+        };
+        if !matches!(url.scheme(), "http" | "https") {
+            continue;
+        }
+        let url = url.to_string();
+        if !seen.insert(url.clone()) {
+            continue;
+        }
+        let text = normalize_whitespace(&element.text().collect::<Vec<_>>().join(" "));
+        links.push(FetchLink { text, url });
+        if links.len() >= 256 {
+            break;
+        }
+    }
+
+    Ok(links)
+}
+
+pub(crate) fn normalize_whitespace(input: &str) -> String {
+    input.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+pub(crate) fn truncate_chars(input: &str, max_chars: usize) -> (String, bool) {
+    if max_chars == 0 {
+        return (String::new(), !input.is_empty());
+    }
+    let mut chars = input.chars();
+    let mut output = String::with_capacity(input.len().min(max_chars));
+    for _ in 0..max_chars {
+        let Some(ch) = chars.next() else {
+            return (output, false);
+        };
+        output.push(ch);
+    }
+    let truncated = chars.next().is_some();
+    (output, truncated)
+}
+
+fn is_html_type(content_type: &str) -> bool {
+    matches!(content_type, "text/html" | "application/xhtml+xml")
+}
+
+fn is_text_type(content_type: &str) -> bool {
+    content_type.starts_with("text/")
+        || matches!(
+            content_type,
+            "application/json"
+                | "application/ld+json"
+                | "application/xml"
+                | "application/rss+xml"
+                | "application/atom+xml"
+        )
+}
+
+fn looks_like_html(body: &[u8]) -> bool {
+    let prefix = String::from_utf8_lossy(&body[..body.len().min(512)]).to_ascii_lowercase();
+    prefix.contains("<!doctype html") || prefix.contains("<html") || prefix.contains("<body")
+}
+
+fn looks_like_text(body: &[u8]) -> bool {
+    if body.is_empty() {
+        return true;
+    }
+    let sample = &body[..body.len().min(1024)];
+    let suspicious = sample
+        .iter()
+        .filter(|byte| **byte == 0 || (**byte < 0x09) || (**byte > 0x0d && **byte < 0x20))
+        .count();
+    suspicious * 20 < sample.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_title_text_and_absolute_links() {
+        let html = br#"
+            <html><head><title> Example Page </title></head>
+            <body><main><h1>Hello</h1><p>Readable text.</p>
+            <a href="/docs"> Docs </a><a href="mailto:a@example.com">Mail</a></main></body></html>
+        "#;
+        let page = extract_body(
+            Some("text/html; charset=utf-8"),
+            html,
+            "https://example.com/start",
+            1000,
+            true,
+            false,
+        )
+        .unwrap();
+        assert_eq!(page.title.as_deref(), Some("Example Page"));
+        assert!(page.text.contains("Hello Readable text."));
+        assert_eq!(page.links.len(), 1);
+        assert_eq!(page.links[0].url, "https://example.com/docs");
+    }
+
+    #[test]
+    fn removes_script_style_and_navigation_text() {
+        let html = br#"
+            <html><head><title>Title</title><style>.x{}</style></head>
+            <body><nav>Menu Noise</nav><main><p>Keep me</p><script>secret()</script></main></body></html>
+        "#;
+        let page = extract_body(
+            Some("text/html"),
+            html,
+            "https://example.com/",
+            1000,
+            false,
+            false,
+        )
+        .unwrap();
+        assert_eq!(page.text, "Keep me");
+    }
+
+    #[test]
+    fn truncation_is_character_deterministic() {
+        let (text, truncated) = truncate_chars("абвгд", 3);
+        assert_eq!(text, "абв");
+        assert!(truncated);
+        let (text, truncated) = truncate_chars("abc", 3);
+        assert_eq!(text, "abc");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn binary_is_explicit() {
+        let error = extract_body(
+            Some("application/octet-stream"),
+            &[0, 1, 2, 3],
+            "https://example.com/file.bin",
+            100,
+            false,
+            false,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind, WebErrorKind::UnsupportedContentType);
+
+        let page = extract_body(
+            Some("application/octet-stream"),
+            &[0, 1, 2, 3],
+            "https://example.com/file.bin",
+            100,
+            false,
+            true,
+        )
+        .unwrap();
+        assert_eq!(page.kind, FetchBodyKind::Binary);
+    }
+}

--- a/crates/impetus-core/src/web_research/http.rs
+++ b/crates/impetus-core/src/web_research/http.rs
@@ -1,0 +1,629 @@
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use reqwest::{
+    Response, StatusCode, Url,
+    header::{ACCEPT, HeaderMap, LOCATION},
+    redirect::Policy as RedirectPolicy,
+};
+use tokio::net::lookup_host;
+
+use super::{EgressPolicy, WebError, WebErrorKind};
+
+const DEFAULT_MAX_REDIRECTS: usize = 5;
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+#[async_trait]
+pub trait DnsResolver: Send + Sync {
+    async fn resolve(&self, host: &str, port: u16) -> Result<Vec<SocketAddr>, WebError>;
+}
+
+#[derive(Debug, Default)]
+pub struct SystemDnsResolver;
+
+#[async_trait]
+impl DnsResolver for SystemDnsResolver {
+    async fn resolve(&self, host: &str, port: u16) -> Result<Vec<SocketAddr>, WebError> {
+        let mut addresses: Vec<_> = lookup_host((host, port))
+            .await
+            .map_err(|error| {
+                WebError::new(
+                    WebErrorKind::DnsResolutionFailed,
+                    format!("DNS resolution failed for {host}: {error}"),
+                )
+            })?
+            .collect();
+        addresses.sort_by_key(|address| address.to_string());
+        addresses.dedup();
+        if addresses.is_empty() {
+            return Err(WebError::new(
+                WebErrorKind::DnsResolutionFailed,
+                format!("DNS resolution returned no addresses for {host}"),
+            ));
+        }
+        Ok(addresses)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PreparedGet {
+    pub url: Url,
+    pub resolved_addr: SocketAddr,
+    pub max_bytes: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct PreparedPostForm {
+    pub url: Url,
+    pub resolved_addr: SocketAddr,
+    pub max_bytes: usize,
+    pub form: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RawHttpResponse {
+    pub status: StatusCode,
+    pub headers: HeaderMap,
+    pub body: Vec<u8>,
+    pub body_truncated: bool,
+}
+
+#[async_trait]
+pub trait HttpTransport: Send + Sync {
+    async fn get(&self, request: PreparedGet) -> Result<RawHttpResponse, WebError>;
+
+    async fn post_form(&self, request: PreparedPostForm) -> Result<RawHttpResponse, WebError> {
+        Err(WebError::new(
+            WebErrorKind::Configuration,
+            "HTTP transport does not implement form POST",
+        )
+        .with_url(request.url.to_string()))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReqwestTransport {
+    connect_timeout: Duration,
+    request_timeout: Duration,
+    user_agent: String,
+}
+
+impl Default for ReqwestTransport {
+    fn default() -> Self {
+        Self {
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
+            user_agent: DEFAULT_USER_AGENT.to_string(),
+        }
+    }
+}
+
+impl ReqwestTransport {
+    pub fn with_user_agent(mut self, user_agent: impl Into<String>) -> Self {
+        self.user_agent = user_agent.into();
+        self
+    }
+
+    fn client_for(
+        &self,
+        url: &Url,
+        resolved_addr: SocketAddr,
+    ) -> Result<reqwest::Client, WebError> {
+        let host = url.host_str().ok_or_else(|| {
+            WebError::new(
+                WebErrorKind::InvalidUrl,
+                "request URL does not contain a host",
+            )
+            .with_url(url.to_string())
+        })?;
+        let mut builder = reqwest::Client::builder()
+            .redirect(RedirectPolicy::none())
+            .connect_timeout(self.connect_timeout)
+            .timeout(self.request_timeout)
+            .user_agent(&self.user_agent)
+            .no_proxy();
+        if host.parse::<IpAddr>().is_err() {
+            builder = builder.resolve(host, resolved_addr);
+        }
+        builder.build().map_err(|error| {
+            WebError::new(
+                WebErrorKind::Transport,
+                format!("failed to build HTTP client: {error}"),
+            )
+            .with_url(url.to_string())
+        })
+    }
+
+    async fn finish_response(
+        &self,
+        response: Response,
+        max_bytes: usize,
+        url: &Url,
+    ) -> Result<RawHttpResponse, WebError> {
+        let status = response.status();
+        let headers = response.headers().clone();
+        if is_redirect_status(status) {
+            return Ok(RawHttpResponse {
+                status,
+                headers,
+                body: Vec::new(),
+                body_truncated: false,
+            });
+        }
+        let content_length_exceeds_limit = response
+            .content_length()
+            .is_some_and(|content_length| content_length > max_bytes as u64);
+        let mut body = Vec::with_capacity(max_bytes.min(64 * 1024));
+        let mut body_truncated = false;
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|error| {
+                WebError::new(
+                    WebErrorKind::Transport,
+                    format!("failed while reading response body: {error}"),
+                )
+                .with_url(url.to_string())
+            })?;
+            let remaining = max_bytes.saturating_sub(body.len());
+            if chunk.len() > remaining {
+                body.extend_from_slice(&chunk[..remaining]);
+                body_truncated = true;
+                break;
+            }
+            body.extend_from_slice(&chunk);
+            if body.len() == max_bytes {
+                body_truncated = content_length_exceeds_limit;
+                if body_truncated {
+                    break;
+                }
+            }
+        }
+        Ok(RawHttpResponse {
+            status,
+            headers,
+            body,
+            body_truncated,
+        })
+    }
+}
+
+#[async_trait]
+impl HttpTransport for ReqwestTransport {
+    async fn get(&self, request: PreparedGet) -> Result<RawHttpResponse, WebError> {
+        let client = self.client_for(&request.url, request.resolved_addr)?;
+        let response = client
+            .get(request.url.clone())
+            .header(
+                ACCEPT,
+                "text/html,application/xhtml+xml,application/json,text/plain;q=0.9,*/*;q=0.8",
+            )
+            .send()
+            .await
+            .map_err(|error| {
+                WebError::new(WebErrorKind::Transport, format!("HTTP GET failed: {error}"))
+                    .with_url(request.url.to_string())
+            })?;
+        self.finish_response(response, request.max_bytes, &request.url)
+            .await
+    }
+
+    async fn post_form(&self, request: PreparedPostForm) -> Result<RawHttpResponse, WebError> {
+        let client = self.client_for(&request.url, request.resolved_addr)?;
+        let response = client
+            .post(request.url.clone())
+            .header(ACCEPT, "text/html,application/xhtml+xml")
+            .form(&request.form)
+            .send()
+            .await
+            .map_err(|error| {
+                WebError::new(
+                    WebErrorKind::Transport,
+                    format!("HTTP form POST failed: {error}"),
+                )
+                .with_url(request.url.to_string())
+            })?;
+        self.finish_response(response, request.max_bytes, &request.url)
+            .await
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SecureHttpResponse {
+    pub requested_url: String,
+    pub final_url: String,
+    pub redirect_chain: Vec<String>,
+    pub status: StatusCode,
+    pub headers: HeaderMap,
+    pub body: Vec<u8>,
+    pub body_truncated: bool,
+}
+
+#[derive(Clone)]
+pub struct SecureHttpClient {
+    transport: Arc<dyn HttpTransport>,
+    resolver: Arc<dyn DnsResolver>,
+    egress: EgressPolicy,
+    max_redirects: usize,
+}
+
+impl std::fmt::Debug for SecureHttpClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SecureHttpClient")
+            .field("egress", &self.egress)
+            .field("max_redirects", &self.max_redirects)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Clone)]
+enum RequestMode {
+    Get,
+    PostForm(Vec<(String, String)>),
+}
+
+impl SecureHttpClient {
+    pub fn production(egress: EgressPolicy) -> Self {
+        Self::new(
+            Arc::new(ReqwestTransport::default()),
+            Arc::new(SystemDnsResolver),
+            egress,
+        )
+    }
+
+    pub fn new(
+        transport: Arc<dyn HttpTransport>,
+        resolver: Arc<dyn DnsResolver>,
+        egress: EgressPolicy,
+    ) -> Self {
+        Self {
+            transport,
+            resolver,
+            egress,
+            max_redirects: DEFAULT_MAX_REDIRECTS,
+        }
+    }
+
+    pub fn with_max_redirects(mut self, max_redirects: usize) -> Self {
+        self.max_redirects = max_redirects;
+        self
+    }
+
+    pub fn egress_policy(&self) -> &EgressPolicy {
+        &self.egress
+    }
+
+    pub async fn get(
+        &self,
+        raw_url: &str,
+        max_bytes: usize,
+    ) -> Result<SecureHttpResponse, WebError> {
+        self.execute(raw_url, max_bytes, RequestMode::Get).await
+    }
+
+    /// Form POST exists only for fixed semantic providers such as DuckDuckGo HTML/Lite.
+    /// `web_fetch` itself remains GET-only; callers must not expose arbitrary POST as an agent tool.
+    pub async fn post_form(
+        &self,
+        raw_url: &str,
+        form: Vec<(String, String)>,
+        max_bytes: usize,
+    ) -> Result<SecureHttpResponse, WebError> {
+        self.execute(raw_url, max_bytes, RequestMode::PostForm(form))
+            .await
+    }
+
+    async fn execute(
+        &self,
+        raw_url: &str,
+        max_bytes: usize,
+        mut mode: RequestMode,
+    ) -> Result<SecureHttpResponse, WebError> {
+        if max_bytes == 0 {
+            return Err(WebError::new(
+                WebErrorKind::InvalidRequest,
+                "max_bytes must be greater than zero",
+            )
+            .with_url(raw_url));
+        }
+        let requested_url = raw_url.to_string();
+        let mut current = self.egress.validate_url(raw_url)?;
+        let mut redirect_chain = Vec::new();
+
+        for hop in 0..=self.max_redirects {
+            let resolved_addr = self.resolve_and_validate(&current).await?;
+            let response = match &mode {
+                RequestMode::Get => {
+                    self.transport
+                        .get(PreparedGet {
+                            url: current.clone(),
+                            resolved_addr,
+                            max_bytes,
+                        })
+                        .await?
+                }
+                RequestMode::PostForm(form) => {
+                    self.transport
+                        .post_form(PreparedPostForm {
+                            url: current.clone(),
+                            resolved_addr,
+                            max_bytes,
+                            form: form.clone(),
+                        })
+                        .await?
+                }
+            };
+
+            if !is_redirect_status(response.status) {
+                return Ok(SecureHttpResponse {
+                    requested_url,
+                    final_url: current.to_string(),
+                    redirect_chain,
+                    status: response.status,
+                    headers: response.headers,
+                    body: response.body,
+                    body_truncated: response.body_truncated,
+                });
+            }
+            if hop == self.max_redirects {
+                return Err(WebError::new(
+                    WebErrorKind::RedirectLimit,
+                    format!("redirect limit ({}) exceeded", self.max_redirects),
+                )
+                .with_url(current.to_string()));
+            }
+
+            let location = response
+                .headers
+                .get(LOCATION)
+                .ok_or_else(|| {
+                    WebError::new(
+                        WebErrorKind::RedirectMissingLocation,
+                        "redirect response does not contain a Location header",
+                    )
+                    .with_url(current.to_string())
+                })?
+                .to_str()
+                .map_err(|_| {
+                    WebError::new(
+                        WebErrorKind::RedirectMissingLocation,
+                        "redirect Location header is not valid UTF-8",
+                    )
+                    .with_url(current.to_string())
+                })?;
+            let next = current.join(location).map_err(|error| {
+                WebError::new(
+                    WebErrorKind::InvalidUrl,
+                    format!("invalid redirect target: {error}"),
+                )
+                .with_url(current.to_string())
+            })?;
+            let next = self.egress.validate_url(next.as_str())?;
+            redirect_chain.push(next.to_string());
+
+            // Browser-compatible redirect semantics: 303 always becomes GET; 301/302 from
+            // a form POST become GET; 307/308 preserve method and body.
+            if matches!(&mode, RequestMode::PostForm(_))
+                && matches!(
+                    response.status,
+                    StatusCode::MOVED_PERMANENTLY | StatusCode::FOUND | StatusCode::SEE_OTHER
+                )
+            {
+                mode = RequestMode::Get;
+            }
+            current = next;
+        }
+        unreachable!("redirect loop exits by response or error")
+    }
+
+    async fn resolve_and_validate(&self, url: &Url) -> Result<SocketAddr, WebError> {
+        let host = url.host_str().ok_or_else(|| {
+            WebError::new(WebErrorKind::InvalidUrl, "URL does not contain a host")
+                .with_url(url.to_string())
+        })?;
+        let port = url.port_or_known_default().ok_or_else(|| {
+            WebError::new(WebErrorKind::PortBlocked, "URL has no usable port")
+                .with_url(url.to_string())
+        })?;
+        let mut addresses = if let Ok(ip) = host.parse::<IpAddr>() {
+            vec![SocketAddr::new(ip, port)]
+        } else {
+            self.resolver.resolve(host, port).await.map_err(|error| {
+                if error.url.is_none() {
+                    error.with_url(url.to_string())
+                } else {
+                    error
+                }
+            })?
+        };
+        addresses.sort_by_key(|address| address.to_string());
+        addresses.dedup();
+        if addresses.is_empty() {
+            return Err(WebError::new(
+                WebErrorKind::DnsResolutionFailed,
+                format!("DNS resolution returned no addresses for {host}"),
+            )
+            .with_url(url.to_string()));
+        }
+        for address in &addresses {
+            self.egress.enforce_address(address.ip(), url.as_str())?;
+        }
+        Ok(addresses[0])
+    }
+}
+
+fn is_redirect_status(status: StatusCode) -> bool {
+    matches!(
+        status,
+        StatusCode::MOVED_PERMANENTLY
+            | StatusCode::FOUND
+            | StatusCode::SEE_OTHER
+            | StatusCode::TEMPORARY_REDIRECT
+            | StatusCode::PERMANENT_REDIRECT
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use std::{
+        collections::{HashMap, VecDeque},
+        sync::Mutex,
+    };
+
+    use reqwest::header::HeaderValue;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MockDns {
+        answers: HashMap<String, Vec<SocketAddr>>,
+    }
+
+    #[async_trait]
+    impl DnsResolver for MockDns {
+        async fn resolve(&self, host: &str, _port: u16) -> Result<Vec<SocketAddr>, WebError> {
+            self.answers.get(host).cloned().ok_or_else(|| {
+                WebError::new(WebErrorKind::DnsResolutionFailed, "missing mock DNS answer")
+            })
+        }
+    }
+
+    #[derive(Default)]
+    struct MockTransport {
+        responses: Mutex<VecDeque<RawHttpResponse>>,
+        requests: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl HttpTransport for MockTransport {
+        async fn get(&self, request: PreparedGet) -> Result<RawHttpResponse, WebError> {
+            self.requests
+                .lock()
+                .unwrap()
+                .push(format!("GET {}", request.url));
+            self.next_response()
+        }
+
+        async fn post_form(&self, request: PreparedPostForm) -> Result<RawHttpResponse, WebError> {
+            self.requests
+                .lock()
+                .unwrap()
+                .push(format!("POST {}", request.url));
+            self.next_response()
+        }
+    }
+
+    impl MockTransport {
+        fn next_response(&self) -> Result<RawHttpResponse, WebError> {
+            self.responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| WebError::new(WebErrorKind::Transport, "missing mock response"))
+        }
+    }
+
+    fn response(status: StatusCode, location: Option<&str>, body: &[u8]) -> RawHttpResponse {
+        let mut headers = HeaderMap::new();
+        if let Some(location) = location {
+            headers.insert(LOCATION, HeaderValue::from_str(location).unwrap());
+        }
+        RawHttpResponse {
+            status,
+            headers,
+            body: body.to_vec(),
+            body_truncated: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn revalidates_dns_after_redirect() {
+        let transport = Arc::new(MockTransport::default());
+        transport.responses.lock().unwrap().extend([
+            response(
+                StatusCode::FOUND,
+                Some("https://private.example/secret"),
+                b"",
+            ),
+            response(StatusCode::OK, None, b"should never be reached"),
+        ]);
+        let mut dns = MockDns::default();
+        dns.answers.insert(
+            "public.example".into(),
+            vec!["93.184.216.34:443".parse().unwrap()],
+        );
+        dns.answers.insert(
+            "private.example".into(),
+            vec!["127.0.0.1:443".parse().unwrap()],
+        );
+        let client =
+            SecureHttpClient::new(transport.clone(), Arc::new(dns), EgressPolicy::default());
+        let error = client
+            .get("https://public.example/start", 1024)
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind, WebErrorKind::AddressBlocked);
+        assert_eq!(transport.requests.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn blocks_mixed_public_and_private_dns_answers() {
+        let transport = Arc::new(MockTransport::default());
+        let mut dns = MockDns::default();
+        dns.answers.insert(
+            "mixed.example".into(),
+            vec![
+                "93.184.216.34:443".parse().unwrap(),
+                "10.0.0.2:443".parse().unwrap(),
+            ],
+        );
+        let client =
+            SecureHttpClient::new(transport.clone(), Arc::new(dns), EgressPolicy::default());
+        let error = client
+            .get("https://mixed.example/", 1024)
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind, WebErrorKind::AddressBlocked);
+        assert!(transport.requests.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn post_302_becomes_get_and_rechecks_redirect_host() {
+        let transport = Arc::new(MockTransport::default());
+        transport.responses.lock().unwrap().extend([
+            response(StatusCode::FOUND, Some("https://next.example/results"), b""),
+            response(StatusCode::OK, None, b"ok"),
+        ]);
+        let mut dns = MockDns::default();
+        dns.answers.insert(
+            "search.example".into(),
+            vec!["93.184.216.34:443".parse().unwrap()],
+        );
+        dns.answers.insert(
+            "next.example".into(),
+            vec!["93.184.216.35:443".parse().unwrap()],
+        );
+        let client =
+            SecureHttpClient::new(transport.clone(), Arc::new(dns), EgressPolicy::default());
+        let response = client
+            .post_form(
+                "https://search.example/query",
+                vec![("q".into(), "rust".into())],
+                1024,
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.final_url, "https://next.example/results");
+        let requests = transport.requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0], "POST https://search.example/query");
+        assert_eq!(requests[1], "GET https://next.example/results");
+    }
+}

--- a/crates/impetus-core/src/web_research/mod.rs
+++ b/crates/impetus-core/src/web_research/mod.rs
@@ -1,0 +1,37 @@
+mod bing;
+mod browser;
+mod doctor;
+mod duckduckgo;
+mod html;
+mod http;
+mod searxng;
+mod security;
+mod service;
+mod tool_adapter;
+mod types;
+
+pub use bing::BingHtmlSearchBackend;
+pub use browser::{
+    BrowserCapability, BrowserProvider, BrowserProviderDescriptor, BrowserService,
+    BrowserServiceStatus, ProviderBackedBrowserService,
+};
+pub use doctor::{BackendDoctorStatus, SearchBackendDoctorEntry, WebDoctor, WebDoctorReport};
+pub use duckduckgo::DuckDuckGoSearchBackend;
+pub use http::{
+    DnsResolver, HttpTransport, PreparedGet, PreparedPostForm, RawHttpResponse, ReqwestTransport,
+    SecureHttpClient, SecureHttpResponse, SystemDnsResolver,
+};
+pub use searxng::SearxngSearchBackend;
+pub use security::{AddressClass, EgressPolicy};
+pub use service::{
+    ArtifactPolicy, ExternalSearchBackend, SearchBackend, WebFetchService, WebResearchEngine,
+    WebResearchService, WebSearchService,
+};
+pub use tool_adapter::{execute_web_tool, redact_url_for_observation};
+pub use types::{
+    CitationSource, DEFAULT_FETCH_MAX_BYTES, DEFAULT_FETCH_MAX_CHARS, DEFAULT_SEARCH_RESULTS,
+    FetchBodyKind, FetchLink, FetchRequest, FetchedPage, MAX_FETCH_BYTES, MAX_FETCH_CHARS,
+    MAX_FETCH_URL_CHARS, MAX_SEARCH_QUERY_CHARS, MAX_SEARCH_RESULTS, SafeSearch, SearchAttempt,
+    SearchBackendPreference, SearchHit, SearchRequest, SearchResponse, WebCapability, WebError,
+    WebErrorKind, WebObservation, WebOutcome, WebToolObservationDetail,
+};

--- a/crates/impetus-core/src/web_research/searxng.rs
+++ b/crates/impetus-core/src/web_research/searxng.rs
@@ -1,0 +1,216 @@
+use std::{sync::Arc, time::Instant};
+
+use async_trait::async_trait;
+use reqwest::{Url, header::CONTENT_TYPE};
+use serde::Deserialize;
+
+use super::{
+    SafeSearch, SearchAttempt, SearchHit, SearchRequest, SearchResponse, SecureHttpClient,
+    WebError, WebErrorKind, WebOutcome,
+    service::{SearchBackend, citation_id},
+};
+
+const SEARCH_BODY_LIMIT: usize = 2 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct SearxngSearchBackend {
+    id: String,
+    base_url: Url,
+    http: Arc<SecureHttpClient>,
+}
+
+impl SearxngSearchBackend {
+    pub fn new(
+        id: impl Into<String>,
+        base_url: impl AsRef<str>,
+        http: Arc<SecureHttpClient>,
+    ) -> Result<Self, WebError> {
+        let id = id.into();
+        if id.trim().is_empty() {
+            return Err(WebError::new(
+                WebErrorKind::Configuration,
+                "SearXNG backend id must not be empty",
+            ));
+        }
+        let mut base_url = Url::parse(base_url.as_ref()).map_err(|error| {
+            WebError::new(
+                WebErrorKind::Configuration,
+                format!("invalid SearXNG base URL: {error}"),
+            )
+        })?;
+        if !matches!(base_url.scheme(), "http" | "https") {
+            return Err(WebError::new(
+                WebErrorKind::UnsupportedScheme,
+                "SearXNG base URL must use HTTP or HTTPS",
+            )
+            .with_url(base_url.to_string()));
+        }
+        base_url.set_query(None);
+        base_url.set_fragment(None);
+        if !base_url.path().ends_with('/') {
+            let path = format!("{}/", base_url.path());
+            base_url.set_path(&path);
+        }
+        Ok(Self { id, base_url, http })
+    }
+
+    fn search_url(&self, request: &SearchRequest) -> Result<Url, WebError> {
+        let mut url = self.base_url.join("search").map_err(|error| {
+            WebError::new(
+                WebErrorKind::Configuration,
+                format!("failed to build SearXNG search URL: {error}"),
+            )
+        })?;
+        {
+            let mut pairs = url.query_pairs_mut();
+            pairs.append_pair("q", request.query.trim());
+            pairs.append_pair("format", "json");
+            if let Some(locale) = request
+                .locale
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                pairs.append_pair("language", locale);
+            }
+            let safe = match request.safe_search {
+                SafeSearch::Off => "0",
+                SafeSearch::Moderate => "1",
+                SafeSearch::Strict => "2",
+            };
+            pairs.append_pair("safesearch", safe);
+        }
+        Ok(url)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SearxngResponse {
+    #[serde(default)]
+    results: Vec<SearxngResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearxngResult {
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    url: String,
+    #[serde(default)]
+    content: Option<String>,
+}
+
+#[async_trait]
+impl SearchBackend for SearxngSearchBackend {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn search(&self, request: &SearchRequest) -> Result<SearchResponse, WebError> {
+        let started = Instant::now();
+        let url = self.search_url(request)?;
+        let response = self.http.get(url.as_str(), SEARCH_BODY_LIMIT).await?;
+        if !response.status.is_success() {
+            return Err(WebError::new(
+                WebErrorKind::BackendUnavailable,
+                format!("SearXNG returned HTTP {}", response.status.as_u16()),
+            )
+            .with_url(response.final_url));
+        }
+        let content_type = response
+            .headers
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        if !content_type.is_empty() && !content_type.to_ascii_lowercase().contains("json") {
+            return Err(WebError::new(
+                WebErrorKind::BackendUnavailable,
+                "SearXNG JSON format is unavailable or disabled on this instance",
+            )
+            .with_url(response.final_url));
+        }
+        let parsed: SearxngResponse = serde_json::from_slice(&response.body).map_err(|error| {
+            WebError::new(
+                WebErrorKind::BackendUnavailable,
+                format!("SearXNG returned invalid JSON: {error}"),
+            )
+            .with_url(response.final_url.clone())
+        })?;
+        let hits = map_results(parsed, request.normalized_limit(), self.id());
+        let outcome = if hits.is_empty() {
+            WebOutcome::NoResults
+        } else {
+            WebOutcome::Success
+        };
+        Ok(SearchResponse {
+            outcome,
+            backend: self.id().into(),
+            query: request.query.clone(),
+            hits,
+            attempts: vec![SearchAttempt {
+                backend: self.id().into(),
+                endpoint: response.final_url,
+                outcome,
+                detail: None,
+            }],
+            elapsed_ms: elapsed_ms(started),
+        })
+    }
+}
+
+fn map_results(response: SearxngResponse, max_results: usize, backend: &str) -> Vec<SearchHit> {
+    response
+        .results
+        .into_iter()
+        .filter_map(|result| {
+            let parsed = Url::parse(result.url.trim()).ok()?;
+            if !matches!(parsed.scheme(), "http" | "https") {
+                return None;
+            }
+            let url = parsed.to_string();
+            let title = if result.title.trim().is_empty() {
+                url.clone()
+            } else {
+                result.title.trim().to_string()
+            };
+            Some((title, url, result.content.unwrap_or_default()))
+        })
+        .take(max_results)
+        .enumerate()
+        .map(|(index, (title, url, snippet))| SearchHit {
+            rank: index + 1,
+            title,
+            citation_id: citation_id("search", &url),
+            url,
+            snippet: snippet.trim().to_string(),
+            backend: backend.to_string(),
+        })
+        .collect()
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_json_results_and_drops_non_http_urls() {
+        let response: SearxngResponse = serde_json::from_str(
+            r#"{
+              "results": [
+                {"title":"A","url":"https://example.com/a","content":"alpha"},
+                {"title":"bad","url":"javascript:alert(1)","content":"bad"},
+                {"title":"","url":"https://example.org/b"}
+              ]
+            }"#,
+        )
+        .unwrap();
+        let hits = map_results(response, 10, "searxng:test");
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].backend, "searxng:test");
+        assert_eq!(hits[1].title, "https://example.org/b");
+    }
+}

--- a/crates/impetus-core/src/web_research/security.rs
+++ b/crates/impetus-core/src/web_research/security.rs
@@ -1,0 +1,289 @@
+use std::{
+    collections::BTreeSet,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+};
+
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+
+use super::{WebError, WebErrorKind};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AddressClass {
+    Public,
+    Private,
+    NonRoutable,
+}
+
+#[derive(Debug, Clone)]
+pub struct EgressPolicy {
+    pub allow_private_network: bool,
+    pub allowed_ports: BTreeSet<u16>,
+    pub blocked_host_suffixes: Vec<String>,
+}
+
+impl Default for EgressPolicy {
+    fn default() -> Self {
+        Self {
+            allow_private_network: false,
+            allowed_ports: BTreeSet::from([80, 443]),
+            blocked_host_suffixes: vec![
+                "localhost".into(),
+                ".localhost".into(),
+                ".local".into(),
+                ".internal".into(),
+                ".home.arpa".into(),
+            ],
+        }
+    }
+}
+
+impl EgressPolicy {
+    pub fn validate_url(&self, raw: &str) -> Result<Url, WebError> {
+        let url = Url::parse(raw).map_err(|error| {
+            WebError::new(WebErrorKind::InvalidUrl, format!("invalid URL: {error}")).with_url(raw)
+        })?;
+
+        match url.scheme() {
+            "http" | "https" => {}
+            scheme => {
+                return Err(WebError::new(
+                    WebErrorKind::UnsupportedScheme,
+                    format!("scheme '{scheme}' is not allowed for web research"),
+                )
+                .with_url(raw));
+            }
+        }
+
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(WebError::new(
+                WebErrorKind::CredentialsInUrl,
+                "credentials embedded in URLs are not allowed",
+            )
+            .with_url(raw));
+        }
+
+        let port = url.port_or_known_default().ok_or_else(|| {
+            WebError::new(WebErrorKind::PortBlocked, "URL has no usable port").with_url(raw)
+        })?;
+        if !self.allowed_ports.contains(&port) {
+            return Err(WebError::new(
+                WebErrorKind::PortBlocked,
+                format!("port {port} is not allowed by web egress policy"),
+            )
+            .with_url(raw));
+        }
+
+        let host = url.host_str().ok_or_else(|| {
+            WebError::new(WebErrorKind::InvalidUrl, "URL does not contain a host").with_url(raw)
+        })?;
+        let normalized_host = host.trim_end_matches('.').to_ascii_lowercase();
+        if !self.allow_private_network && self.host_is_blocked(&normalized_host) {
+            return Err(WebError::new(
+                WebErrorKind::HostBlocked,
+                format!("host '{host}' is blocked by web egress policy"),
+            )
+            .with_url(raw));
+        }
+
+        if let Ok(address) = normalized_host.parse::<IpAddr>() {
+            self.enforce_address(address, raw)?;
+        }
+
+        Ok(url)
+    }
+
+    pub fn enforce_address(&self, address: IpAddr, url: &str) -> Result<(), WebError> {
+        match classify_address(address) {
+            AddressClass::Public => Ok(()),
+            AddressClass::Private if self.allow_private_network => Ok(()),
+            AddressClass::Private => Err(WebError::new(
+                WebErrorKind::AddressBlocked,
+                format!("private/local address {address} is blocked"),
+            )
+            .with_url(url)),
+            AddressClass::NonRoutable => Err(WebError::new(
+                WebErrorKind::AddressBlocked,
+                format!("non-routable/special address {address} is blocked"),
+            )
+            .with_url(url)),
+        }
+    }
+
+    fn host_is_blocked(&self, host: &str) -> bool {
+        self.blocked_host_suffixes.iter().any(|entry| {
+            if let Some(suffix) = entry.strip_prefix('.') {
+                host == suffix || host.ends_with(entry)
+            } else {
+                host == entry
+            }
+        })
+    }
+}
+
+pub fn classify_address(address: IpAddr) -> AddressClass {
+    match address {
+        IpAddr::V4(address) => classify_v4(address),
+        IpAddr::V6(address) => classify_v6(address),
+    }
+}
+
+fn classify_v4(address: Ipv4Addr) -> AddressClass {
+    let octets = address.octets();
+    let first = octets[0];
+    let second = octets[1];
+
+    if first == 0
+        || address.is_unspecified()
+        || address.is_multicast()
+        || address == Ipv4Addr::BROADCAST
+        || first >= 240
+        || (first == 192 && second == 0 && octets[2] == 0)
+        || (first == 192 && second == 0 && octets[2] == 2)
+        || (first == 192 && second == 88 && octets[2] == 99)
+        || (first == 198 && (18..=19).contains(&second))
+        || (first == 198 && second == 51 && octets[2] == 100)
+        || (first == 203 && second == 0 && octets[2] == 113)
+    {
+        return AddressClass::NonRoutable;
+    }
+
+    if address.is_private()
+        || address.is_loopback()
+        || address.is_link_local()
+        || (first == 100 && (64..=127).contains(&second))
+    {
+        return AddressClass::Private;
+    }
+
+    AddressClass::Public
+}
+
+fn classify_v6(address: Ipv6Addr) -> AddressClass {
+    if let Some(mapped) = address.to_ipv4_mapped() {
+        return classify_v4(mapped);
+    }
+
+    let segments = address.segments();
+    let first = segments[0];
+
+    if address.is_unspecified()
+        || address.is_multicast()
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8)
+    {
+        return AddressClass::NonRoutable;
+    }
+
+    if address.is_loopback()
+        || (first & 0xfe00) == 0xfc00 // fc00::/7 unique local
+        || (first & 0xffc0) == 0xfe80 // fe80::/10 link local
+        || (first & 0xffc0) == 0xfec0
+    // fec0::/10 deprecated site local
+    {
+        return AddressClass::Private;
+    }
+
+    AddressClass::Public
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_non_http_schemes_and_credentials() {
+        let policy = EgressPolicy::default();
+        assert_eq!(
+            policy.validate_url("file:///etc/passwd").unwrap_err().kind,
+            WebErrorKind::UnsupportedScheme
+        );
+        assert_eq!(
+            policy
+                .validate_url("https://user:secret@example.com/")
+                .unwrap_err()
+                .kind,
+            WebErrorKind::CredentialsInUrl
+        );
+    }
+
+    #[test]
+    fn rejects_local_hosts_and_unapproved_ports() {
+        let policy = EgressPolicy::default();
+        assert_eq!(
+            policy
+                .validate_url("http://localhost:80/")
+                .unwrap_err()
+                .kind,
+            WebErrorKind::HostBlocked
+        );
+        assert_eq!(
+            policy
+                .validate_url("https://example.com:8443/")
+                .unwrap_err()
+                .kind,
+            WebErrorKind::PortBlocked
+        );
+    }
+
+    #[test]
+    fn classifies_private_and_special_ranges() {
+        for ip in [
+            "127.0.0.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.169.254",
+            "100.64.0.1",
+            "::1",
+            "fc00::1",
+            "fe80::1",
+        ] {
+            assert_eq!(
+                classify_address(ip.parse().unwrap()),
+                AddressClass::Private,
+                "{ip}"
+            );
+        }
+
+        for ip in [
+            "0.0.0.0",
+            "192.0.2.1",
+            "198.51.100.3",
+            "203.0.113.9",
+            "2001:db8::1",
+        ] {
+            assert_eq!(
+                classify_address(ip.parse().unwrap()),
+                AddressClass::NonRoutable,
+                "{ip}"
+            );
+        }
+
+        assert_eq!(
+            classify_address("1.1.1.1".parse().unwrap()),
+            AddressClass::Public
+        );
+    }
+
+    #[test]
+    fn private_network_requires_explicit_opt_in() {
+        let mut policy = EgressPolicy::default();
+        assert!(
+            policy
+                .enforce_address("10.1.2.3".parse().unwrap(), "http://10.1.2.3")
+                .is_err()
+        );
+        policy.allow_private_network = true;
+        assert!(
+            policy
+                .enforce_address("10.1.2.3".parse().unwrap(), "http://10.1.2.3")
+                .is_ok()
+        );
+        assert!(
+            policy
+                .enforce_address("192.0.2.1".parse().unwrap(), "http://192.0.2.1")
+                .is_err()
+        );
+    }
+}

--- a/crates/impetus-core/src/web_research/service.rs
+++ b/crates/impetus-core/src/web_research/service.rs
@@ -1,0 +1,674 @@
+use std::{collections::BTreeMap, fmt::Write as _, sync::Arc, time::Instant};
+
+use async_trait::async_trait;
+use reqwest::header::CONTENT_TYPE;
+use sha2::{Digest, Sha256};
+
+use crate::DurableArtifactStore;
+
+use super::{
+    BingHtmlSearchBackend, CitationSource, DuckDuckGoSearchBackend, EgressPolicy, FetchRequest,
+    FetchedPage, MAX_FETCH_URL_CHARS, MAX_SEARCH_QUERY_CHARS, SearchBackendPreference,
+    SearchRequest, SearchResponse, SecureHttpClient, WebError, WebErrorKind, WebOutcome,
+    WebToolObservationDetail, html::extract_body,
+};
+
+#[async_trait]
+pub trait SearchBackend: Send + Sync {
+    fn id(&self) -> &str;
+    async fn search(&self, request: &SearchRequest) -> Result<SearchResponse, WebError>;
+}
+
+pub trait ExternalSearchBackend: SearchBackend {}
+impl<T: SearchBackend + ?Sized> ExternalSearchBackend for T {}
+
+#[async_trait]
+pub trait WebSearchService: Send + Sync {
+    async fn search(&self, request: SearchRequest) -> Result<SearchResponse, WebError>;
+}
+
+#[async_trait]
+pub trait WebFetchService: Send + Sync {
+    async fn fetch(&self, request: FetchRequest) -> Result<FetchedPage, WebError>;
+}
+
+pub trait WebResearchService: WebSearchService + WebFetchService {}
+impl<T> WebResearchService for T where T: WebSearchService + WebFetchService + ?Sized {}
+
+#[derive(Debug, Clone)]
+pub struct ArtifactPolicy {
+    pub persist_threshold_bytes: usize,
+    pub persist_html_always: bool,
+    pub persist_binary_always: bool,
+}
+
+impl Default for ArtifactPolicy {
+    fn default() -> Self {
+        Self {
+            persist_threshold_bytes: 64 * 1024,
+            persist_html_always: true,
+            persist_binary_always: true,
+        }
+    }
+}
+
+pub struct WebResearchEngine {
+    http: Arc<SecureHttpClient>,
+    default_backend: Arc<dyn SearchBackend>,
+    builtin_backends: BTreeMap<String, Arc<dyn SearchBackend>>,
+    builtin_fallback_order: Vec<String>,
+    external_backends: BTreeMap<String, Arc<dyn SearchBackend>>,
+    external_fallback_order: Vec<String>,
+    artifact_store: Option<Arc<DurableArtifactStore>>,
+    artifact_policy: ArtifactPolicy,
+}
+
+impl std::fmt::Debug for WebResearchEngine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebResearchEngine")
+            .field("default_backend", &self.default_backend.id())
+            .field(
+                "builtin_backends",
+                &self.builtin_backends.keys().collect::<Vec<_>>(),
+            )
+            .field("builtin_fallback_order", &self.builtin_fallback_order)
+            .field(
+                "external_backends",
+                &self.external_backends.keys().collect::<Vec<_>>(),
+            )
+            .field("external_fallback_order", &self.external_fallback_order)
+            .field("artifact_store", &self.artifact_store.is_some())
+            .field("artifact_policy", &self.artifact_policy)
+            .finish()
+    }
+}
+
+impl WebResearchEngine {
+    pub fn production(egress: EgressPolicy) -> Self {
+        Self::new(Arc::new(SecureHttpClient::production(egress)))
+    }
+
+    pub fn new(http: Arc<SecureHttpClient>) -> Self {
+        let default_backend: Arc<dyn SearchBackend> =
+            Arc::new(DuckDuckGoSearchBackend::new(http.clone()));
+        let bing_backend: Arc<dyn SearchBackend> =
+            Arc::new(BingHtmlSearchBackend::new(http.clone()));
+        let mut builtin_backends = BTreeMap::new();
+        builtin_backends.insert(default_backend.id().to_string(), default_backend.clone());
+        builtin_backends.insert(bing_backend.id().to_string(), bing_backend);
+        Self {
+            http,
+            default_backend,
+            builtin_backends,
+            builtin_fallback_order: vec!["bing_html".into()],
+            external_backends: BTreeMap::new(),
+            external_fallback_order: Vec::new(),
+            artifact_store: None,
+            artifact_policy: ArtifactPolicy::default(),
+        }
+    }
+
+    pub fn with_default_backend(mut self, backend: Arc<dyn SearchBackend>) -> Self {
+        self.builtin_backends
+            .insert(backend.id().to_string(), backend.clone());
+        self.default_backend = backend;
+        self
+    }
+
+    pub fn with_builtin_fallback(mut self, backend: Arc<dyn SearchBackend>) -> Self {
+        let id = backend.id().to_string();
+        self.builtin_backends.insert(id.clone(), backend);
+        if id != self.default_backend.id() && !self.builtin_fallback_order.contains(&id) {
+            self.builtin_fallback_order.push(id);
+        }
+        self
+    }
+
+    pub fn with_external_backend(
+        mut self,
+        backend: Arc<dyn SearchBackend>,
+        use_as_automatic_fallback: bool,
+    ) -> Self {
+        let id = backend.id().to_string();
+        self.external_backends.insert(id.clone(), backend);
+        if use_as_automatic_fallback && !self.external_fallback_order.contains(&id) {
+            self.external_fallback_order.push(id);
+        }
+        self
+    }
+
+    pub fn with_artifact_store(
+        mut self,
+        store: Arc<DurableArtifactStore>,
+        policy: ArtifactPolicy,
+    ) -> Self {
+        self.artifact_store = Some(store);
+        self.artifact_policy = policy;
+        self
+    }
+
+    pub fn default_backend_id(&self) -> &str {
+        self.default_backend.id()
+    }
+
+    pub fn builtin_backend_ids(&self) -> impl Iterator<Item = &str> {
+        self.builtin_backends.keys().map(String::as_str)
+    }
+
+    pub fn external_backend_ids(&self) -> impl Iterator<Item = &str> {
+        self.external_backends.keys().map(String::as_str)
+    }
+
+    /// Explicit diagnostics probe. This bypasses fallback short-circuiting and calls every
+    /// configured backend once, so doctor can report per-backend reachability. It must never be
+    /// used during normal startup because it performs outbound requests.
+    pub async fn probe_search_backends(
+        &self,
+        request: SearchRequest,
+    ) -> Vec<(String, Result<SearchResponse, WebError>)> {
+        let mut ids = Vec::new();
+        ids.push(self.default_backend.id().to_string());
+        ids.extend(self.builtin_backends.keys().cloned());
+        ids.extend(self.external_backends.keys().cloned());
+        let mut unique = Vec::new();
+        for id in ids {
+            if !unique.contains(&id) {
+                unique.push(id);
+            }
+        }
+
+        let mut results = Vec::with_capacity(unique.len());
+        for id in unique {
+            if let Some(backend) = self.backend_by_id(&id) {
+                results.push((id, backend.search(&request).await));
+            }
+        }
+        results
+    }
+
+    pub fn search_observation_detail(response: &SearchResponse) -> WebToolObservationDetail {
+        WebToolObservationDetail {
+            operation: "web_search".into(),
+            outcome: response.outcome,
+            backend: Some(response.backend.clone()),
+            requested_url: None,
+            final_url: None,
+            query: Some(response.query.clone()),
+            elapsed_ms: response.elapsed_ms,
+            citations: response
+                .hits
+                .iter()
+                .map(|hit| CitationSource {
+                    citation_id: hit.citation_id.clone(),
+                    url: hit.url.clone(),
+                    title: Some(hit.title.clone()),
+                    artifact: None,
+                })
+                .collect(),
+            error_kind: None,
+            error_message: None,
+        }
+    }
+
+    pub fn fetch_observation_detail(page: &FetchedPage) -> WebToolObservationDetail {
+        WebToolObservationDetail {
+            operation: "web_fetch".into(),
+            outcome: page.outcome,
+            backend: None,
+            requested_url: Some(page.requested_url.clone()),
+            final_url: Some(page.final_url.clone()),
+            query: None,
+            elapsed_ms: page.elapsed_ms,
+            citations: vec![page.citation.clone()],
+            error_kind: None,
+            error_message: None,
+        }
+    }
+
+    pub fn error_observation_detail(
+        operation: &str,
+        error: &WebError,
+        query: Option<String>,
+        requested_url: Option<String>,
+    ) -> WebToolObservationDetail {
+        WebToolObservationDetail {
+            operation: operation.into(),
+            outcome: if error.blocked() {
+                WebOutcome::Blocked
+            } else {
+                WebOutcome::Failed
+            },
+            backend: None,
+            requested_url,
+            final_url: error.url.clone(),
+            query,
+            elapsed_ms: 0,
+            citations: Vec::new(),
+            error_kind: Some(error.kind),
+            error_message: Some(error.message.clone()),
+        }
+    }
+
+    async fn search_automatic(&self, request: &SearchRequest) -> Result<SearchResponse, WebError> {
+        let started = Instant::now();
+        let mut attempts = Vec::new();
+        let mut last_response = None;
+
+        let mut backend_ids = Vec::with_capacity(
+            1 + self.builtin_fallback_order.len() + self.external_fallback_order.len(),
+        );
+        backend_ids.push(self.default_backend.id().to_string());
+        backend_ids.extend(self.builtin_fallback_order.iter().cloned());
+        backend_ids.extend(self.external_fallback_order.iter().cloned());
+        backend_ids.dedup();
+
+        for backend_id in backend_ids {
+            let Some(backend) = self.backend_by_id(&backend_id) else {
+                continue;
+            };
+
+            match backend.search(request).await {
+                Ok(mut response) => {
+                    attempts.append(&mut response.attempts);
+                    response.attempts = attempts.clone();
+                    if response.outcome == WebOutcome::Success && !response.hits.is_empty() {
+                        return Ok(response);
+                    }
+                    last_response = Some(response);
+                }
+                Err(error) => {
+                    attempts.push(super::SearchAttempt {
+                        backend: backend.id().to_string(),
+                        endpoint: "backend".into(),
+                        outcome: if error.blocked() {
+                            WebOutcome::Blocked
+                        } else {
+                            WebOutcome::Failed
+                        },
+                        detail: Some(error.message.clone()),
+                    });
+                }
+            }
+        }
+
+        if let Some(mut response) = last_response {
+            response.attempts = attempts;
+            return Ok(response);
+        }
+        if !attempts.is_empty() {
+            let outcome = if attempts
+                .iter()
+                .any(|attempt| attempt.outcome == WebOutcome::Blocked)
+            {
+                WebOutcome::Blocked
+            } else {
+                WebOutcome::Failed
+            };
+            let backend = attempts
+                .last()
+                .map(|attempt| attempt.backend.clone())
+                .unwrap_or_else(|| "web_search".into());
+            return Ok(SearchResponse {
+                outcome,
+                backend,
+                query: request.query.clone(),
+                hits: Vec::new(),
+                attempts,
+                elapsed_ms: elapsed_ms(started),
+            });
+        }
+        Err(WebError::new(
+            WebErrorKind::BackendUnavailable,
+            "no search backend is available",
+        ))
+    }
+
+    fn backend_by_id(&self, id: &str) -> Option<Arc<dyn SearchBackend>> {
+        if id == self.default_backend.id() {
+            return Some(self.default_backend.clone());
+        }
+        self.builtin_backends
+            .get(id)
+            .or_else(|| self.external_backends.get(id))
+            .cloned()
+    }
+
+    fn backend_by_preference(
+        &self,
+        preference: &SearchBackendPreference,
+    ) -> Result<Arc<dyn SearchBackend>, WebError> {
+        let id = match preference {
+            SearchBackendPreference::Automatic => return Ok(self.default_backend.clone()),
+            SearchBackendPreference::DuckDuckGo => "duckduckgo",
+            SearchBackendPreference::BingHtml => "bing_html",
+            SearchBackendPreference::External(id) => {
+                return self.external_backends.get(id).cloned().ok_or_else(|| {
+                    WebError::new(
+                        WebErrorKind::BackendUnavailable,
+                        format!("external search backend '{id}' is not registered"),
+                    )
+                });
+            }
+        };
+        self.builtin_backends.get(id).cloned().ok_or_else(|| {
+            WebError::new(
+                WebErrorKind::BackendUnavailable,
+                format!("built-in search backend '{id}' is not registered"),
+            )
+        })
+    }
+
+    fn persist_body_if_needed(
+        &self,
+        final_url: &str,
+        body: &[u8],
+        kind: super::FetchBodyKind,
+    ) -> Result<Option<crate::DurableArtifactRef>, WebError> {
+        let should_persist = body.len() >= self.artifact_policy.persist_threshold_bytes
+            || (kind == super::FetchBodyKind::Html && self.artifact_policy.persist_html_always)
+            || (kind == super::FetchBodyKind::Binary && self.artifact_policy.persist_binary_always);
+        if !should_persist {
+            return Ok(None);
+        }
+        let Some(store) = &self.artifact_store else {
+            return Ok(None);
+        };
+
+        store.store(body).map(Some).map_err(|error| {
+            WebError::new(
+                WebErrorKind::ArtifactStore,
+                format!("failed to persist fetched body: {error}"),
+            )
+            .with_url(final_url)
+        })
+    }
+}
+
+#[async_trait]
+impl WebSearchService for WebResearchEngine {
+    async fn search(&self, request: SearchRequest) -> Result<SearchResponse, WebError> {
+        if request.query.trim().is_empty() {
+            return Err(WebError::new(
+                WebErrorKind::InvalidRequest,
+                "search query must not be empty",
+            ));
+        }
+        if request.query.chars().count() > MAX_SEARCH_QUERY_CHARS {
+            return Err(WebError::new(
+                WebErrorKind::InvalidRequest,
+                format!("search query exceeds {MAX_SEARCH_QUERY_CHARS} characters"),
+            ));
+        }
+
+        match &request.backend {
+            SearchBackendPreference::Automatic => self.search_automatic(&request).await,
+            preference => {
+                self.backend_by_preference(preference)?
+                    .search(&request)
+                    .await
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl WebFetchService for WebResearchEngine {
+    async fn fetch(&self, request: FetchRequest) -> Result<FetchedPage, WebError> {
+        if request.url.trim().is_empty() {
+            return Err(WebError::new(
+                WebErrorKind::InvalidRequest,
+                "fetch URL must not be empty",
+            ));
+        }
+        if request.url.chars().count() > MAX_FETCH_URL_CHARS {
+            return Err(WebError::new(
+                WebErrorKind::InvalidRequest,
+                format!("fetch URL exceeds {MAX_FETCH_URL_CHARS} characters"),
+            ));
+        }
+        if request.max_bytes == 0 || request.max_chars == 0 {
+            return Err(WebError::new(
+                WebErrorKind::InvalidRequest,
+                "fetch max_bytes and max_chars must be greater than zero",
+            ));
+        }
+
+        let started = Instant::now();
+        let max_bytes = request.bounded_max_bytes();
+        let max_chars = request.bounded_max_chars();
+        let response = self.http.get(&request.url, max_bytes).await?;
+        if !response.status.is_success() {
+            return Err(WebError::new(
+                WebErrorKind::HttpStatus,
+                format!("HTTP fetch returned status {}", response.status.as_u16()),
+            )
+            .with_url(response.final_url));
+        }
+
+        let content_type = response
+            .headers
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
+        let extracted = extract_body(
+            content_type.as_deref(),
+            &response.body,
+            &response.final_url,
+            max_chars,
+            request.include_links,
+            request.allow_binary_metadata,
+        )?;
+
+        let content_sha256 = sha256_hex(&response.body);
+        let artifact =
+            self.persist_body_if_needed(&response.final_url, &response.body, extracted.kind)?;
+        let citation_id = citation_id("fetch", &response.final_url);
+
+        Ok(FetchedPage {
+            outcome: WebOutcome::Success,
+            requested_url: response.requested_url,
+            final_url: response.final_url.clone(),
+            redirect_chain: response.redirect_chain,
+            status_code: response.status.as_u16(),
+            content_type,
+            body_kind: extracted.kind,
+            title: extracted.title.clone(),
+            text: extracted.text,
+            links: extracted.links,
+            truncated: extracted.truncated || response.body_truncated,
+            citation: CitationSource {
+                citation_id,
+                url: response.final_url,
+                title: extracted.title,
+                artifact,
+            },
+            fetched_unix_ms: now_unix_ms(),
+            content_sha256,
+            elapsed_ms: started.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
+        })
+    }
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn now_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis().try_into().unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+pub(crate) fn citation_id(namespace: &str, value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(namespace.as_bytes());
+    hasher.update([0]);
+    hasher.update(value.as_bytes());
+    let digest = hasher.finalize();
+    let mut suffix = String::with_capacity(16);
+    for byte in digest.iter().take(8) {
+        let _ = write!(&mut suffix, "{byte:02x}");
+    }
+    format!("web-{suffix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::*;
+    use crate::web_research::{EgressPolicy, SearchAttempt, SearchHit};
+
+    struct FixedBackend {
+        id: &'static str,
+        outcome: WebOutcome,
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl SearchBackend for FixedBackend {
+        fn id(&self) -> &str {
+            self.id
+        }
+
+        async fn search(&self, request: &SearchRequest) -> Result<SearchResponse, WebError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let hits = if self.outcome == WebOutcome::Success {
+                vec![SearchHit {
+                    rank: 1,
+                    title: "Example".into(),
+                    url: "https://example.com/".into(),
+                    snippet: "example".into(),
+                    backend: self.id.into(),
+                    citation_id: citation_id("search", "https://example.com/"),
+                }]
+            } else {
+                Vec::new()
+            };
+            Ok(SearchResponse {
+                outcome: self.outcome,
+                backend: self.id.into(),
+                query: request.query.clone(),
+                hits,
+                attempts: vec![SearchAttempt {
+                    backend: self.id.into(),
+                    endpoint: self.id.into(),
+                    outcome: self.outcome,
+                    detail: None,
+                }],
+                elapsed_ms: 0,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn automatic_search_falls_back_from_duckduckgo_to_bing_html() {
+        let ddg_calls = Arc::new(AtomicUsize::new(0));
+        let bing_calls = Arc::new(AtomicUsize::new(0));
+        let http = Arc::new(SecureHttpClient::production(EgressPolicy::default()));
+        let engine = WebResearchEngine::new(http)
+            .with_default_backend(Arc::new(FixedBackend {
+                id: "duckduckgo",
+                outcome: WebOutcome::Failed,
+                calls: ddg_calls.clone(),
+            }))
+            .with_builtin_fallback(Arc::new(FixedBackend {
+                id: "bing_html",
+                outcome: WebOutcome::Success,
+                calls: bing_calls.clone(),
+            }));
+
+        let response = engine.search(SearchRequest::new("rust")).await.unwrap();
+        assert_eq!(response.outcome, WebOutcome::Success);
+        assert_eq!(response.backend, "bing_html");
+        assert_eq!(response.attempts.len(), 2);
+        assert_eq!(ddg_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(bing_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn fetch_persists_bounded_raw_body_when_artifact_policy_requires_it() {
+        use std::{net::SocketAddr, sync::Mutex};
+
+        use reqwest::{
+            StatusCode,
+            header::{CONTENT_TYPE, HeaderMap, HeaderValue},
+        };
+
+        use crate::web_research::{DnsResolver, HttpTransport, PreparedGet, RawHttpResponse};
+
+        struct Dns;
+
+        #[async_trait]
+        impl DnsResolver for Dns {
+            async fn resolve(&self, _host: &str, port: u16) -> Result<Vec<SocketAddr>, WebError> {
+                Ok(vec![SocketAddr::new(
+                    "93.184.216.34".parse().unwrap(),
+                    port,
+                )])
+            }
+        }
+
+        struct Transport(Mutex<Option<RawHttpResponse>>);
+
+        #[async_trait]
+        impl HttpTransport for Transport {
+            async fn get(&self, _request: PreparedGet) -> Result<RawHttpResponse, WebError> {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .ok_or_else(|| WebError::new(WebErrorKind::Transport, "missing mock response"))
+            }
+        }
+
+        let body =
+            b"<html><head><title>Example</title></head><body><main>Hello web</main></body></html>"
+                .to_vec();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("text/html; charset=utf-8"),
+        );
+        let transport = Arc::new(Transport(Mutex::new(Some(RawHttpResponse {
+            status: StatusCode::OK,
+            headers,
+            body: body.clone(),
+            body_truncated: false,
+        }))));
+        let http = Arc::new(SecureHttpClient::new(
+            transport,
+            Arc::new(Dns),
+            EgressPolicy::default(),
+        ));
+        let temp = tempfile::tempdir().unwrap();
+        let store = Arc::new(DurableArtifactStore::open(temp.path()).unwrap());
+        let engine = WebResearchEngine::new(http).with_artifact_store(
+            store.clone(),
+            ArtifactPolicy {
+                persist_threshold_bytes: usize::MAX,
+                persist_html_always: true,
+                persist_binary_always: true,
+            },
+        );
+
+        let page = engine
+            .fetch(FetchRequest::new("https://example.com/page"))
+            .await
+            .unwrap();
+        assert_eq!(page.title.as_deref(), Some("Example"));
+        assert_eq!(page.text, "Hello web");
+        let artifact = page.citation.artifact.expect("raw body artifact");
+        assert_eq!(store.read(&artifact.id).unwrap(), body);
+    }
+}

--- a/crates/impetus-core/src/web_research/tool_adapter.rs
+++ b/crates/impetus-core/src/web_research/tool_adapter.rs
@@ -1,0 +1,379 @@
+use std::fmt::Write as _;
+
+use regex::Regex;
+use reqwest::Url;
+
+use crate::{DurableArtifactStore, ToolCall, ToolEventOutcome, ToolObservation};
+
+use super::{
+    FetchRequest, FetchedPage, SearchRequest, SearchResponse, WebError, WebObservation, WebOutcome,
+    WebResearchService,
+};
+
+const PREVIEW_CHAR_LIMIT: usize = 24_000;
+
+/// Execute semantic web tools without exposing provider details to Agent Loop.
+/// Returns `None` for non-web tools so ToolOrchestrator can keep its existing path.
+pub async fn execute_web_tool(
+    service: &dyn WebResearchService,
+    tool_call: &ToolCall,
+    artifacts: &DurableArtifactStore,
+) -> Option<ToolObservation> {
+    match tool_call.name.as_str() {
+        "web_search" => Some(execute_search(service, tool_call, artifacts).await),
+        "web_fetch" => Some(execute_fetch(service, tool_call, artifacts).await),
+        _ => None,
+    }
+}
+
+async fn execute_search(
+    service: &dyn WebResearchService,
+    tool_call: &ToolCall,
+    artifacts: &DurableArtifactStore,
+) -> ToolObservation {
+    let request: SearchRequest = match serde_json::from_value(tool_call.arguments.clone()) {
+        Ok(request) => request,
+        Err(error) => {
+            return failed_observation(tool_call, format!("invalid web_search arguments: {error}"));
+        }
+    };
+    let arguments_summary = format!(
+        "query={} chars, max_results={}",
+        request.query.chars().count(),
+        request.normalized_limit()
+    );
+
+    match service.search(request).await {
+        Ok(response) => observation_from_search(tool_call, arguments_summary, response, artifacts),
+        Err(error) => observation_from_error(tool_call, arguments_summary, error),
+    }
+}
+
+async fn execute_fetch(
+    service: &dyn WebResearchService,
+    tool_call: &ToolCall,
+    artifacts: &DurableArtifactStore,
+) -> ToolObservation {
+    let request: FetchRequest = match serde_json::from_value(tool_call.arguments.clone()) {
+        Ok(request) => request,
+        Err(error) => {
+            return failed_observation(tool_call, format!("invalid web_fetch arguments: {error}"));
+        }
+    };
+    let arguments_summary = format!("url={}", redact_url_for_observation(&request.url));
+
+    match service.fetch(request).await {
+        Ok(page) => observation_from_fetch(tool_call, arguments_summary, page, artifacts),
+        Err(error) => observation_from_error(tool_call, arguments_summary, error),
+    }
+}
+
+fn observation_from_search(
+    tool_call: &ToolCall,
+    arguments_summary: String,
+    mut response: SearchResponse,
+    artifacts: &DurableArtifactStore,
+) -> ToolObservation {
+    for hit in &mut response.hits {
+        hit.url = redact_url_for_observation(&hit.url);
+    }
+    let query_chars = response.query.chars().count();
+    response.query = format!("<redacted:{query_chars} chars>");
+    let artifact = persist_json(artifacts, &WebObservation::Search(response.clone()));
+    let mut preview = String::new();
+    let _ = writeln!(
+        &mut preview,
+        "web_search: {:?} via {} ({} ms)",
+        response.outcome, response.backend, response.elapsed_ms
+    );
+    for hit in &response.hits {
+        let _ = writeln!(
+            &mut preview,
+            "\n[{}] {}\n{}\n{}",
+            hit.citation_id, hit.title, hit.url, hit.snippet
+        );
+    }
+    preview = truncate_preview(preview);
+
+    ToolObservation {
+        tool_call_id: tool_call.id.clone(),
+        tool_name: tool_call.name.clone(),
+        arguments_summary,
+        outcome: map_outcome(response.outcome),
+        preview,
+        artifact,
+        error: if response.outcome == WebOutcome::Failed {
+            response
+                .attempts
+                .last()
+                .and_then(|attempt| attempt.detail.as_deref())
+                .map(|detail| sanitize_urls_in_message(detail, true))
+        } else {
+            None
+        },
+    }
+}
+
+fn observation_from_fetch(
+    tool_call: &ToolCall,
+    arguments_summary: String,
+    mut page: FetchedPage,
+    artifacts: &DurableArtifactStore,
+) -> ToolObservation {
+    // Query-string credentials/signatures should not be copied into durable metadata.
+    page.requested_url = redact_url_for_observation(&page.requested_url);
+    page.final_url = redact_url_for_observation(&page.final_url);
+    page.redirect_chain = page
+        .redirect_chain
+        .iter()
+        .map(|url| redact_url_for_observation(url))
+        .collect();
+    page.citation.url = redact_url_for_observation(&page.citation.url);
+    for link in &mut page.links {
+        link.url = redact_url_for_observation(&link.url);
+    }
+
+    let artifact = persist_json(artifacts, &WebObservation::Fetch(page.clone()));
+    let mut preview = String::new();
+    let _ = writeln!(
+        &mut preview,
+        "web_fetch: {} [{}] ({} ms)",
+        page.final_url, page.citation.citation_id, page.elapsed_ms
+    );
+    if let Some(title) = &page.title {
+        let _ = writeln!(&mut preview, "title: {title}");
+    }
+    let _ = writeln!(&mut preview, "\n{}", page.text);
+    preview = truncate_preview(preview);
+
+    ToolObservation {
+        tool_call_id: tool_call.id.clone(),
+        tool_name: tool_call.name.clone(),
+        arguments_summary,
+        outcome: map_outcome(page.outcome),
+        preview,
+        artifact,
+        error: None,
+    }
+}
+
+fn observation_from_error(
+    tool_call: &ToolCall,
+    arguments_summary: String,
+    mut error: WebError,
+) -> ToolObservation {
+    if let Some(url) = error.url.take() {
+        error.url = Some(if tool_call.name == "web_search" {
+            redact_search_url(&url)
+        } else {
+            redact_url_for_observation(&url)
+        });
+    }
+    let sanitized_message =
+        sanitize_urls_in_message(&error.message, tool_call.name == "web_search");
+    error.message = sanitized_message;
+    ToolObservation {
+        tool_call_id: tool_call.id.clone(),
+        tool_name: tool_call.name.clone(),
+        arguments_summary,
+        outcome: if error.blocked() {
+            ToolEventOutcome::Denied
+        } else {
+            ToolEventOutcome::Error
+        },
+        preview: String::new(),
+        artifact: None,
+        error: Some(error.to_string()),
+    }
+}
+
+fn failed_observation(tool_call: &ToolCall, error: String) -> ToolObservation {
+    ToolObservation {
+        tool_call_id: tool_call.id.clone(),
+        tool_name: tool_call.name.clone(),
+        arguments_summary: "invalid web tool arguments".into(),
+        outcome: ToolEventOutcome::Error,
+        preview: String::new(),
+        artifact: None,
+        error: Some(error),
+    }
+}
+
+fn persist_json<T: serde::Serialize>(
+    artifacts: &DurableArtifactStore,
+    value: &T,
+) -> Option<crate::DurableArtifactRef> {
+    serde_json::to_vec(value)
+        .ok()
+        .and_then(|bytes| artifacts.store(&bytes).ok())
+}
+
+fn map_outcome(outcome: WebOutcome) -> ToolEventOutcome {
+    match outcome {
+        WebOutcome::Success | WebOutcome::NoResults => ToolEventOutcome::Success,
+        WebOutcome::Blocked => ToolEventOutcome::Denied,
+        WebOutcome::Failed => ToolEventOutcome::Error,
+    }
+}
+
+fn truncate_preview(input: String) -> String {
+    let mut chars = input.chars();
+    let mut output = String::with_capacity(input.len().min(PREVIEW_CHAR_LIMIT));
+    for _ in 0..PREVIEW_CHAR_LIMIT {
+        let Some(ch) = chars.next() else {
+            return output;
+        };
+        output.push(ch);
+    }
+    if chars.next().is_some() {
+        output.push_str("\n...[preview truncated; full result is stored as an artifact]");
+    }
+    output
+}
+
+fn redact_search_url(raw: &str) -> String {
+    let Ok(mut url) = Url::parse(raw) else {
+        return "<invalid-url>".into();
+    };
+    url.set_query(None);
+    url.set_fragment(None);
+    url.to_string()
+}
+
+fn sanitize_urls_in_message(message: &str, strip_all_query: bool) -> String {
+    let Ok(regex) = Regex::new(r"https?://[^\s)\]}>]+") else {
+        return message.to_string();
+    };
+    regex
+        .replace_all(message, |captures: &regex::Captures<'_>| {
+            if strip_all_query {
+                redact_search_url(&captures[0])
+            } else {
+                redact_url_for_observation(&captures[0])
+            }
+        })
+        .into_owned()
+}
+
+pub fn redact_url_for_observation(raw: &str) -> String {
+    let Ok(mut url) = Url::parse(raw) else {
+        return "<invalid-url>".into();
+    };
+    if url.query().is_none() {
+        return url.to_string();
+    }
+
+    let pairs: Vec<(String, String)> = url
+        .query_pairs()
+        .map(|(key, value)| {
+            let normalized = key.to_ascii_lowercase().replace('-', "_");
+            let sensitive = [
+                "token",
+                "access_token",
+                "api_key",
+                "apikey",
+                "key",
+                "secret",
+                "signature",
+                "sig",
+                "auth",
+                "authorization",
+                "password",
+                "passwd",
+                "x_amz_signature",
+                "x_amz_credential",
+            ]
+            .iter()
+            .any(|candidate| normalized == *candidate || normalized.ends_with(candidate));
+            (
+                key.into_owned(),
+                if sensitive {
+                    "<redacted>".into()
+                } else {
+                    value.into_owned()
+                },
+            )
+        })
+        .collect();
+
+    url.set_query(None);
+    {
+        let mut query = url.query_pairs_mut();
+        for (key, value) in pairs {
+            query.append_pair(&key, &value);
+        }
+    }
+    url.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::web_research::{SearchAttempt, WebErrorKind, WebFetchService, WebSearchService};
+
+    #[test]
+    fn redacts_sensitive_query_values_but_keeps_navigation_parameters() {
+        let redacted = redact_url_for_observation(
+            "https://example.com/file?page=2&token=abc&X-Amz-Signature=deadbeef",
+        );
+        assert!(redacted.contains("page=2"));
+        assert!(!redacted.contains("abc"));
+        assert!(!redacted.contains("deadbeef"));
+        assert!(redacted.contains("%3Credacted%3E"));
+    }
+
+    struct SearchOnlyService;
+
+    #[async_trait]
+    impl WebSearchService for SearchOnlyService {
+        async fn search(&self, request: SearchRequest) -> Result<SearchResponse, WebError> {
+            Ok(SearchResponse {
+                outcome: WebOutcome::NoResults,
+                backend: "mock".into(),
+                query: request.query,
+                hits: Vec::new(),
+                attempts: vec![SearchAttempt {
+                    backend: "mock".into(),
+                    endpoint: "mock".into(),
+                    outcome: WebOutcome::NoResults,
+                    detail: None,
+                }],
+                elapsed_ms: 1,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl WebFetchService for SearchOnlyService {
+        async fn fetch(&self, _request: FetchRequest) -> Result<FetchedPage, WebError> {
+            Err(WebError::new(
+                WebErrorKind::BackendUnavailable,
+                "fetch is not implemented in this mock",
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn durable_search_artifact_redacts_the_raw_query_field() {
+        let temp = tempfile::tempdir().unwrap();
+        let artifacts = DurableArtifactStore::open(temp.path()).unwrap();
+        let call = ToolCall {
+            id: "tool-1".into(),
+            name: "web_search".into(),
+            arguments: serde_json::json!({"query": "secret-query-value"}),
+        };
+
+        let observation = execute_web_tool(&SearchOnlyService, &call, &artifacts)
+            .await
+            .expect("web observation");
+        let artifact = observation.artifact.expect("structured result artifact");
+        let bytes = artifacts.read(&artifact.id).unwrap();
+        let stored: WebObservation = serde_json::from_slice(&bytes).unwrap();
+        let WebObservation::Search(response) = stored else {
+            panic!("expected search observation");
+        };
+        assert_eq!(response.query, "<redacted:18 chars>");
+    }
+}

--- a/crates/impetus-core/src/web_research/types.rs
+++ b/crates/impetus-core/src/web_research/types.rs
@@ -1,0 +1,296 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::DurableArtifactRef;
+
+pub const DEFAULT_SEARCH_RESULTS: usize = 8;
+pub const MAX_SEARCH_RESULTS: usize = 20;
+pub const MAX_SEARCH_QUERY_CHARS: usize = 4_096;
+pub const DEFAULT_FETCH_MAX_BYTES: usize = 2 * 1024 * 1024;
+pub const MAX_FETCH_BYTES: usize = 5 * 1024 * 1024;
+pub const DEFAULT_FETCH_MAX_CHARS: usize = 120_000;
+pub const MAX_FETCH_CHARS: usize = 200_000;
+pub const MAX_FETCH_URL_CHARS: usize = 16_384;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SafeSearch {
+    Off,
+    #[default]
+    Moderate,
+    Strict,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "id")]
+pub enum SearchBackendPreference {
+    #[default]
+    Automatic,
+    DuckDuckGo,
+    BingHtml,
+    External(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchRequest {
+    pub query: String,
+    #[serde(default = "default_search_results")]
+    pub max_results: usize,
+    #[serde(default)]
+    pub locale: Option<String>,
+    #[serde(default)]
+    pub safe_search: SafeSearch,
+    #[serde(default)]
+    pub backend: SearchBackendPreference,
+}
+
+impl SearchRequest {
+    pub fn new(query: impl Into<String>) -> Self {
+        Self {
+            query: query.into(),
+            max_results: DEFAULT_SEARCH_RESULTS,
+            locale: None,
+            safe_search: SafeSearch::Moderate,
+            backend: SearchBackendPreference::Automatic,
+        }
+    }
+
+    pub fn normalized_limit(&self) -> usize {
+        self.max_results.clamp(1, MAX_SEARCH_RESULTS)
+    }
+}
+
+fn default_search_results() -> usize {
+    DEFAULT_SEARCH_RESULTS
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchHit {
+    pub rank: usize,
+    pub title: String,
+    pub url: String,
+    pub snippet: String,
+    pub backend: String,
+    pub citation_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebCapability {
+    Search,
+    Read,
+    PrivateRead,
+    Download,
+    Browser,
+    Submit,
+    Upload,
+}
+
+impl WebCapability {
+    pub fn is_read_only(self) -> bool {
+        matches!(self, Self::Search | Self::Read | Self::PrivateRead)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebOutcome {
+    Success,
+    NoResults,
+    Blocked,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchAttempt {
+    pub backend: String,
+    pub endpoint: String,
+    pub outcome: WebOutcome,
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchResponse {
+    pub outcome: WebOutcome,
+    pub backend: String,
+    pub query: String,
+    pub hits: Vec<SearchHit>,
+    pub attempts: Vec<SearchAttempt>,
+    pub elapsed_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FetchRequest {
+    pub url: String,
+    #[serde(default = "default_fetch_max_bytes")]
+    pub max_bytes: usize,
+    #[serde(default = "default_fetch_max_chars")]
+    pub max_chars: usize,
+    #[serde(default = "default_true")]
+    pub include_links: bool,
+    #[serde(default)]
+    pub allow_binary_metadata: bool,
+}
+
+impl FetchRequest {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            max_bytes: DEFAULT_FETCH_MAX_BYTES,
+            max_chars: DEFAULT_FETCH_MAX_CHARS,
+            include_links: true,
+            allow_binary_metadata: false,
+        }
+    }
+
+    pub fn bounded_max_bytes(&self) -> usize {
+        self.max_bytes.clamp(1, MAX_FETCH_BYTES)
+    }
+
+    pub fn bounded_max_chars(&self) -> usize {
+        self.max_chars.clamp(1, MAX_FETCH_CHARS)
+    }
+}
+
+fn default_fetch_max_bytes() -> usize {
+    DEFAULT_FETCH_MAX_BYTES
+}
+
+fn default_fetch_max_chars() -> usize {
+    DEFAULT_FETCH_MAX_CHARS
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FetchBodyKind {
+    Html,
+    Text,
+    Binary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FetchLink {
+    pub text: String,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CitationSource {
+    pub citation_id: String,
+    pub url: String,
+    pub title: Option<String>,
+    pub artifact: Option<DurableArtifactRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FetchedPage {
+    pub outcome: WebOutcome,
+    pub requested_url: String,
+    pub final_url: String,
+    pub redirect_chain: Vec<String>,
+    pub status_code: u16,
+    pub content_type: Option<String>,
+    pub body_kind: FetchBodyKind,
+    pub title: Option<String>,
+    pub text: String,
+    pub links: Vec<FetchLink>,
+    pub truncated: bool,
+    pub citation: CitationSource,
+    pub fetched_unix_ms: u64,
+    pub content_sha256: String,
+    pub elapsed_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "data", rename_all = "snake_case")]
+pub enum WebObservation {
+    Search(SearchResponse),
+    Fetch(FetchedPage),
+    Detail(WebToolObservationDetail),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebToolObservationDetail {
+    pub operation: String,
+    pub outcome: WebOutcome,
+    pub backend: Option<String>,
+    pub requested_url: Option<String>,
+    pub final_url: Option<String>,
+    pub query: Option<String>,
+    pub elapsed_ms: u64,
+    pub citations: Vec<CitationSource>,
+    pub error_kind: Option<WebErrorKind>,
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebErrorKind {
+    InvalidRequest,
+    InvalidUrl,
+    UnsupportedScheme,
+    CredentialsInUrl,
+    PortBlocked,
+    HostBlocked,
+    DnsResolutionFailed,
+    AddressBlocked,
+    RedirectLimit,
+    RedirectMissingLocation,
+    Transport,
+    HttpStatus,
+    BodyTooLarge,
+    UnsupportedContentType,
+    BackendUnavailable,
+    ArtifactStore,
+    Configuration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebError {
+    pub kind: WebErrorKind,
+    pub message: String,
+    pub url: Option<String>,
+}
+
+impl WebError {
+    pub fn new(kind: WebErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            url: None,
+        }
+    }
+
+    pub fn with_url(mut self, url: impl Into<String>) -> Self {
+        self.url = Some(url.into());
+        self
+    }
+
+    pub fn blocked(&self) -> bool {
+        matches!(
+            self.kind,
+            WebErrorKind::UnsupportedScheme
+                | WebErrorKind::CredentialsInUrl
+                | WebErrorKind::PortBlocked
+                | WebErrorKind::HostBlocked
+                | WebErrorKind::AddressBlocked
+        )
+    }
+}
+
+impl fmt::Display for WebError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(url) = &self.url {
+            write!(f, "{} ({url})", self.message)
+        } else {
+            f.write_str(&self.message)
+        }
+    }
+}
+
+impl std::error::Error for WebError {}

--- a/crates/impetus-core/tests/agent_skills_integration.rs
+++ b/crates/impetus-core/tests/agent_skills_integration.rs
@@ -140,9 +140,7 @@ async fn import_multiple_skills() {
             .await
             .expect("Import should succeed");
 
-        if let (ImportCapability::Supported, Some(spec)) =
-            (result.capability, result.canonical)
-        {
+        if let (ImportCapability::Supported, Some(spec)) = (result.capability, result.canonical) {
             registry
                 .register(spec)
                 .expect("Registration should succeed");

--- a/crates/impetus-core/tests/fixtures/web/ddg_html.html
+++ b/crates/impetus-core/tests/fixtures/web/ddg_html.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html><body>
+<div class="result results_links web-result">
+  <h2><a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.rust-lang.org%2F&rut=aaa">Rust Programming Language</a></h2>
+  <a class="result__snippet">A language empowering everyone to build reliable software.</a>
+</div>
+<div class="result results_links web-result">
+  <h2><a class="result__a" href="https://doc.rust-lang.org/book/">The Rust Programming Language Book</a></h2>
+  <a class="result__snippet">Learn Rust.</a>
+</div>
+</body></html>

--- a/crates/impetus-core/tests/fixtures/web/ddg_lite.html
+++ b/crates/impetus-core/tests/fixtures/web/ddg_lite.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html><body><table>
+<tr><td><a class="result-link" href="https://www.rust-lang.org/">Rust Programming Language</a></td></tr>
+<tr><td class="result-snippet">A language empowering everyone.</td></tr>
+<tr><td><a class="result-link" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fdoc.rust-lang.org%2Fbook%2F">The Rust Book</a></td></tr>
+<tr><td class="result-snippet">Learn Rust from the book.</td></tr>
+</table></body></html>

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,11 @@ confidence-threshold = 0.8
 multiple-versions = "warn"
 wildcards = "allow"
 
+[advisories]
+# syntect 5.3.0 is the TUI's pinned transitive source of bincode 1.3.3. RustSec
+# reports no safe upgrade; revisit when syntect removes this dependency.
+ignore = ["RUSTSEC-2025-0141"]
+
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"


### PR DESCRIPTION
## Summary

- Adds native Rust WebResearchService with web_search and web_fetch.
- Routes semantic tools through ToolOrchestrator policy admission, EffectSeam, secure egress, durable observations, and ArtifactStore.
- Uses DuckDuckGo HTML then Bing HTML, with a configurable SearXNG backend seam.
- Adds offline-safe doctor reporting and fixes the merged Agent Skills adapter integration tests required by the full workspace gate.

## Safety

- HTTP/HTTPS only; bounded requests, redirects, MIME handling, body/model previews, citations, provenance, and durable artifacts.
- Blocks local/private/metadata destinations; validates DNS and redirects and pins validated addresses.
- No Chromium, Playwright, Node runtime, or Bing Search API v7.

## Source audit

JCode audit pin: 1jehuang/jcode@008abc44b1653efa65ccf98acb3b7236ce8507e6.

- ADAPT: service contracts, fallback ordering, anti-bot handling, bounded output, cleanup, and browser-provider seam.
- REIMPLEMENT: Rust HTTP, SSRF controls, policy/effect integration, durable observations/artifacts.
- SKIP: concrete browser providers and retired Bing Search API v7.

## Verification

- cargo fmt --all -- --check
- cargo check --workspace
- cargo test --workspace: 436 passed, 2 ignored
- cargo clippy --workspace --all-targets -- -D warnings
- task verify and task security

## Remaining limits

- Public web reads remain fail-closed behind the existing network approval policy; no session-level read-only grant or approved web-resume path is added here.
- Browser providers, explicit live doctor probing, and API-backed search modules remain optional follow-up work.