### PR TITLE
feat: add VimTrap modularity architecture (closes #63)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -110,7 +110,8 @@
 - **Phase 0**: Foundation (done) — IPC, policy, events, sandbox
 - **Phase 1**: Binary topology & diagnostics (done) — doctor, daemon discovery
 - **Phase 2**: Module runtime (done) — external IPC, fallback policies, tests
-- **Phase 3**: Extension compatibility (in progress) — canonical types, adapters
+- **Phase 3**: Extension compatibility (done) — canonical types, adapters
+- **Phase 3.5**: VimTrap architecture (done) — profile system, service providers, kernel invariants
 - **Phase 4**: Output optimization — structured observations, RTK integration
 - **Phase 5**: Agent runtime — real loop, tool execution, web research
 - **Phase 6**: Context & sessions — lazy loading, artifact store, fork/checkpoint
@@ -122,6 +123,8 @@
 ## Documentation
 
 - **Detailed architecture** (Russian): [ARCHITECTURE.ru.md](ARCHITECTURE.ru.md)
+- **Kernel invariants**: [docs/KERNEL_INVARIANTS.md](docs/KERNEL_INVARIANTS.md)
+- **VimTrap principle**: [docs/VimTrap_Implementation_Plan.md](docs/VimTrap_Implementation_Plan.md)
 - **Roadmap**: [docs/ROADMAP.md](docs/ROADMAP.md)
 - **TODO**: [TODO.md](TODO.md)
 

--- a/crates/impetus-cli/src/main.rs
+++ b/crates/impetus-cli/src/main.rs
@@ -49,6 +49,23 @@ enum Commands {
     },
     /// List all sessions
     List,
+    /// Show current profile and configuration
+    Profile,
+    /// Show service bindings and module status
+    Components {
+        #[command(subcommand)]
+        action: Option<ComponentsAction>,
+    },
+}
+
+#[derive(Subcommand)]
+enum ComponentsAction {
+    /// List all registered modules
+    List,
+    /// Show service bindings
+    Bindings,
+    /// Show module status and health
+    Status,
 }
 
 #[tokio::main]
@@ -181,6 +198,73 @@ async fn main() -> Result<()> {
                     bail!("Error listing sessions: {message}");
                 }
                 other => bail!("Unexpected response: {other:?}"),
+            }
+        }
+        Commands::Profile => {
+            // For now, show default profile configuration
+            // In future, this will query harness for actual runtime profile
+            let profile = impetus_core::Profile::default();
+            let bindings = profile.default_bindings();
+
+            println!("Profile: {:?}", profile);
+            println!("Description: {}", profile.description());
+            println!("\nDefault service bindings:");
+            println!("  agent_loop:      {:?}", bindings.agent_loop);
+            println!("  scheduler:       {:?}", bindings.scheduler);
+            println!("  model_router:    {:?}", bindings.model_router);
+            println!("  context:         {:?}", bindings.context);
+            println!("  reference:       {:?}", bindings.reference);
+            println!("  memory:          {:?}", bindings.memory);
+            println!("  policy:          {:?}", bindings.policy);
+            println!("  tools:           {:?}", bindings.tools);
+            println!("  output_reducer:  {:?}", bindings.output_reducer);
+
+            if !bindings.custom.is_empty() {
+                println!("\nCustom bindings:");
+                for (name, binding) in &bindings.custom {
+                    println!("  {}: {:?}", name, binding);
+                }
+            }
+        }
+        Commands::Components { action } => {
+            match action {
+                None | Some(ComponentsAction::List) => {
+                    // TODO: Query harness for registered modules
+                    println!("Registered modules:");
+                    println!("  (Module registry query not yet implemented via IPC)");
+                    println!("\nBuiltin services:");
+                    println!("  agent_loop (standard)");
+                    println!("  scheduler (standard)");
+                    println!("  model_router (balanced)");
+                    println!("  context (lazy)");
+                    println!("  reference (yaml)");
+                    println!("  memory (standard)");
+                    println!("  policy (standard)");
+                    println!("  tools (standard)");
+                    println!("  output_reducer (standard)");
+                }
+                Some(ComponentsAction::Bindings) => {
+                    let profile = impetus_core::Profile::default();
+                    let bindings = profile.default_bindings();
+
+                    println!("Service bindings:");
+                    println!("  AgentLoop        → {:?}", bindings.agent_loop);
+                    println!("  Scheduler        → {:?}", bindings.scheduler);
+                    println!("  ModelRouter      → {:?}", bindings.model_router);
+                    println!("  ContextService   → {:?}", bindings.context);
+                    println!("  ReferenceService → {:?}", bindings.reference);
+                    println!("  MemoryService    → {:?}", bindings.memory);
+                    println!("  Policy           → {:?}", bindings.policy);
+                    println!("  ToolProvider     → {:?}", bindings.tools);
+                    println!("  OutputReducer    → {:?}", bindings.output_reducer);
+                }
+                Some(ComponentsAction::Status) => {
+                    // TODO: Query harness for module health
+                    println!("Module health status:");
+                    println!("  (Module health query not yet implemented via IPC)");
+                    println!("\nCurrent state:");
+                    println!("  All builtin services: Ready");
+                }
             }
         }
     }

--- a/crates/impetus-core/src/lib.rs
+++ b/crates/impetus-core/src/lib.rs
@@ -36,16 +36,21 @@ pub mod openai_provider;
 pub mod output_reducer;
 pub mod plugins;
 pub mod policy;
+pub mod profile;
 pub mod projection;
 pub mod provider;
 pub mod provider_registry;
 pub mod provider_trait;
+pub mod reference_store;
+pub mod reference_tools;
 pub mod remote;
 pub mod rtk_adapter;
 pub mod runtime;
 pub mod service_contract;
+pub mod service_provider;
 pub mod storage;
 pub mod supervisor;
+pub mod tempo_importer;
 pub mod tool_orchestrator;
 pub mod tools;
 pub mod web_research;
@@ -113,6 +118,7 @@ pub use policy::{
     Action, ActionFingerprint, ActionKind, ActionOrigin, PolicyDecision, PolicyEngine,
     PolicySnapshot, PolicyVersion, SandboxScope,
 };
+pub use profile::{Profile, ProfileConfig, ServiceBinding, ServiceBindings};
 pub use projection::{ProjectionError, SessionProjection, reduce};
 pub use provider::{
     CredentialResolver, CredentialStrategy, NoCredentialResolver, OpenAiCompatibleProvider,
@@ -120,6 +126,16 @@ pub use provider::{
 };
 pub use provider_registry::ProviderRegistry;
 pub use provider_trait::ModelProvider;
+pub use reference_store::{
+    DatasetManifest, DatasetScope, ImportResult as ReferenceImportResult, PartitionStrategy,
+    RecordProvenance, RecordSource, ReferenceRecord, ReferenceService, SearchFilters, SearchResult,
+    Sensitivity, YamlReferenceService,
+};
+pub use reference_tools::{
+    ReferenceGetRequest, ReferenceGetResponse, ReferenceListDatasetsResponse,
+    ReferenceSearchRequest, ReferenceSearchResponse, ReferenceToolError, ReferenceToolKind,
+    ReferenceTools,
+};
 pub use remote::{
     HostKeyFingerprint, HostKeyVerificationError, SSHApproval, SSHApprovalStore,
     SSHApprovalStoreError, SSHConnectionError, SSHConnectionRequest, SSHKeyReference, SSHProfile,
@@ -129,8 +145,12 @@ pub use remote::{
     TmuxSessionStore, TmuxSessionStoreError,
 };
 pub use runtime::{AgentRuntime, RuntimeError, RuntimeStatus};
+pub use service_provider::{
+    ExternalServiceHandle, ResolvedService, ServiceProvider, ServiceProviderKind, ServiceTrait,
+};
 pub use storage::{EventStore, MemoryEventStore, SessionInfo, SqliteEventStore, StoreError};
 pub use supervisor::{MockStreamingProvider, SessionSupervisor, SupervisorError};
+pub use tempo_importer::{TempoImporter, TempoImporterConfig, TempoWorklog};
 pub use tool_orchestrator::{
     OrchestratorError, ToolObservation, ToolOrchestrator, ToolOutcomeStatus, ToolRequest,
 };

--- a/crates/impetus-core/src/profile.rs
+++ b/crates/impetus-core/src/profile.rs
@@ -1,0 +1,218 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Runtime profile selector
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Profile {
+    /// Zero-config daily use with safe defaults
+    #[default]
+    Standard,
+    /// Minimal runtime for debugging/benchmarks
+    Minimal,
+    /// Advanced customization and introspection
+    Creator,
+}
+
+impl Profile {
+    /// Human-readable description
+    pub fn description(&self) -> &'static str {
+        match self {
+            Self::Standard => "Zero-config daily use with safe defaults",
+            Self::Minimal => "Minimal runtime for debugging and benchmarks",
+            Self::Creator => "Advanced customization and introspection enabled",
+        }
+    }
+
+    /// Default service bindings for this profile
+    pub fn default_bindings(&self) -> ServiceBindings {
+        match self {
+            Self::Standard => ServiceBindings {
+                agent_loop: ServiceBinding::Builtin("standard".to_string()),
+                scheduler: ServiceBinding::Builtin("standard".to_string()),
+                model_router: ServiceBinding::Builtin("balanced".to_string()),
+                context: ServiceBinding::Builtin("lazy".to_string()),
+                reference: ServiceBinding::Builtin("yaml".to_string()),
+                memory: ServiceBinding::Builtin("standard".to_string()),
+                policy: ServiceBinding::Builtin("standard".to_string()),
+                tools: ServiceBinding::Builtin("standard".to_string()),
+                output_reducer: ServiceBinding::Builtin("standard".to_string()),
+                custom: HashMap::new(),
+            },
+            Self::Minimal => ServiceBindings {
+                agent_loop: ServiceBinding::Builtin("minimal".to_string()),
+                scheduler: ServiceBinding::Builtin("sync".to_string()),
+                model_router: ServiceBinding::Builtin("direct".to_string()),
+                context: ServiceBinding::Disabled,
+                reference: ServiceBinding::Disabled,
+                memory: ServiceBinding::Disabled,
+                policy: ServiceBinding::Builtin("permissive".to_string()),
+                tools: ServiceBinding::Builtin("minimal".to_string()),
+                output_reducer: ServiceBinding::Disabled,
+                custom: HashMap::new(),
+            },
+            Self::Creator => ServiceBindings {
+                agent_loop: ServiceBinding::Builtin("standard".to_string()),
+                scheduler: ServiceBinding::Builtin("standard".to_string()),
+                model_router: ServiceBinding::Builtin("balanced".to_string()),
+                context: ServiceBinding::Builtin("lazy".to_string()),
+                reference: ServiceBinding::Builtin("yaml".to_string()),
+                memory: ServiceBinding::Builtin("standard".to_string()),
+                policy: ServiceBinding::Builtin("standard".to_string()),
+                tools: ServiceBinding::Builtin("standard".to_string()),
+                output_reducer: ServiceBinding::Builtin("standard".to_string()),
+                custom: HashMap::new(),
+            },
+        }
+    }
+}
+
+/// Service binding specification
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase", tag = "type")]
+pub enum ServiceBinding {
+    /// Built-in implementation with variant name
+    Builtin(String),
+    /// Custom module by ID
+    Custom { module_id: String },
+    /// External module via IPC
+    External { module_id: String },
+    /// Service disabled
+    Disabled,
+}
+
+/// Complete service binding configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceBindings {
+    pub agent_loop: ServiceBinding,
+    pub scheduler: ServiceBinding,
+    pub model_router: ServiceBinding,
+    pub context: ServiceBinding,
+    pub reference: ServiceBinding,
+    pub memory: ServiceBinding,
+    pub policy: ServiceBinding,
+    pub tools: ServiceBinding,
+    pub output_reducer: ServiceBinding,
+    #[serde(default)]
+    pub custom: HashMap<String, ServiceBinding>,
+}
+
+impl Default for ServiceBindings {
+    fn default() -> Self {
+        Profile::default().default_bindings()
+    }
+}
+
+/// Profile configuration with overrides
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ProfileConfig {
+    #[serde(default)]
+    pub profile: Profile,
+    #[serde(default)]
+    pub services: Option<ServiceBindings>,
+}
+
+impl ProfileConfig {
+    /// Resolve effective service bindings (profile defaults + overrides)
+    pub fn resolve_bindings(&self) -> ServiceBindings {
+        let mut bindings = self.profile.default_bindings();
+
+        if let Some(overrides) = &self.services {
+            // Apply overrides
+            if overrides.agent_loop != ServiceBinding::Builtin(String::new()) {
+                bindings.agent_loop = overrides.agent_loop.clone();
+            }
+            if overrides.scheduler != ServiceBinding::Builtin(String::new()) {
+                bindings.scheduler = overrides.scheduler.clone();
+            }
+            if overrides.model_router != ServiceBinding::Builtin(String::new()) {
+                bindings.model_router = overrides.model_router.clone();
+            }
+            if overrides.context != ServiceBinding::Builtin(String::new()) {
+                bindings.context = overrides.context.clone();
+            }
+            if overrides.reference != ServiceBinding::Builtin(String::new()) {
+                bindings.reference = overrides.reference.clone();
+            }
+            if overrides.memory != ServiceBinding::Builtin(String::new()) {
+                bindings.memory = overrides.memory.clone();
+            }
+            if overrides.policy != ServiceBinding::Builtin(String::new()) {
+                bindings.policy = overrides.policy.clone();
+            }
+            if overrides.tools != ServiceBinding::Builtin(String::new()) {
+                bindings.tools = overrides.tools.clone();
+            }
+            if overrides.output_reducer != ServiceBinding::Builtin(String::new()) {
+                bindings.output_reducer = overrides.output_reducer.clone();
+            }
+            // Merge custom bindings
+            bindings.custom.extend(overrides.custom.clone());
+        }
+
+        bindings
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_profile_is_standard() {
+        assert_eq!(Profile::default(), Profile::Standard);
+    }
+
+    #[test]
+    fn test_standard_profile_bindings() {
+        let bindings = Profile::Standard.default_bindings();
+        assert_eq!(
+            bindings.agent_loop,
+            ServiceBinding::Builtin("standard".to_string())
+        );
+        assert_eq!(
+            bindings.model_router,
+            ServiceBinding::Builtin("balanced".to_string())
+        );
+    }
+
+    #[test]
+    fn test_minimal_profile_disables_services() {
+        let bindings = Profile::Minimal.default_bindings();
+        assert_eq!(bindings.context, ServiceBinding::Disabled);
+        assert_eq!(bindings.memory, ServiceBinding::Disabled);
+    }
+
+    #[test]
+    fn test_profile_config_resolve_with_overrides() {
+        let config = ProfileConfig {
+            profile: Profile::Standard,
+            services: Some(ServiceBindings {
+                agent_loop: ServiceBinding::Custom {
+                    module_id: "my-loop".to_string(),
+                },
+                ..Profile::Standard.default_bindings()
+            }),
+        };
+
+        let resolved = config.resolve_bindings();
+        assert_eq!(
+            resolved.agent_loop,
+            ServiceBinding::Custom {
+                module_id: "my-loop".to_string()
+            }
+        );
+        // Other services remain default
+        assert_eq!(
+            resolved.scheduler,
+            ServiceBinding::Builtin("standard".to_string())
+        );
+    }
+
+    #[test]
+    fn test_profile_descriptions() {
+        assert!(!Profile::Standard.description().is_empty());
+        assert!(!Profile::Minimal.description().is_empty());
+        assert!(!Profile::Creator.description().is_empty());
+    }
+}

--- a/crates/impetus-core/src/service_provider.rs
+++ b/crates/impetus-core/src/service_provider.rs
@@ -1,0 +1,268 @@
+use anyhow::Result;
+use std::fmt;
+
+/// Service provider abstraction for replaceable services
+///
+/// Enables dependency injection while maintaining type safety:
+/// - Builtin: compiled-in implementation
+/// - Custom: user-provided implementation (same process)
+/// - External: separate process via IPC
+pub enum ServiceProvider<T> {
+    /// Built-in service implementation
+    Builtin(T),
+    /// Custom user-provided implementation
+    Custom(Box<dyn ServiceTrait<Output = T>>),
+    /// External module via IPC
+    External(ExternalServiceHandle),
+}
+
+impl<T> ServiceProvider<T> {
+    /// Create a builtin provider
+    pub fn builtin(service: T) -> Self {
+        Self::Builtin(service)
+    }
+
+    /// Create a custom provider
+    pub fn custom<S>(service: S) -> Self
+    where
+        S: ServiceTrait<Output = T> + 'static,
+    {
+        Self::Custom(Box::new(service))
+    }
+
+    /// Create an external provider
+    pub fn external(handle: ExternalServiceHandle) -> Self {
+        Self::External(handle)
+    }
+
+    /// Get the service kind
+    pub fn kind(&self) -> ServiceProviderKind {
+        match self {
+            Self::Builtin(_) => ServiceProviderKind::Builtin,
+            Self::Custom(_) => ServiceProviderKind::Custom,
+            Self::External(_) => ServiceProviderKind::External,
+        }
+    }
+
+    /// Get builtin service reference (if available)
+    pub fn as_builtin(&self) -> Option<&T> {
+        match self {
+            Self::Builtin(service) => Some(service),
+            _ => None,
+        }
+    }
+
+    /// Get mutable builtin service reference (if available)
+    pub fn as_builtin_mut(&mut self) -> Option<&mut T> {
+        match self {
+            Self::Builtin(service) => Some(service),
+            _ => None,
+        }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for ServiceProvider<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Builtin(service) => f.debug_tuple("Builtin").field(service).finish(),
+            Self::Custom(_) => f.debug_tuple("Custom").field(&"<trait object>").finish(),
+            Self::External(handle) => f.debug_tuple("External").field(handle).finish(),
+        }
+    }
+}
+
+/// Service provider kind
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceProviderKind {
+    Builtin,
+    Custom,
+    External,
+}
+
+impl fmt::Display for ServiceProviderKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Builtin => write!(f, "builtin"),
+            Self::Custom => write!(f, "custom"),
+            Self::External => write!(f, "external"),
+        }
+    }
+}
+
+/// Trait for custom service implementations
+pub trait ServiceTrait: Send + Sync {
+    type Output;
+
+    fn name(&self) -> &str;
+    fn version(&self) -> &str;
+}
+
+/// Handle to an external service via IPC
+#[derive(Debug, Clone)]
+pub struct ExternalServiceHandle {
+    pub module_id: String,
+    pub socket_path: String,
+}
+
+impl ExternalServiceHandle {
+    pub fn new(module_id: String, socket_path: String) -> Self {
+        Self {
+            module_id,
+            socket_path,
+        }
+    }
+}
+
+/// Service resolution result
+pub enum ResolvedService<T> {
+    Ready(T),
+    Degraded { fallback: T, reason: String },
+    Unavailable { reason: String },
+}
+
+impl<T> ResolvedService<T> {
+    /// Check if service is ready
+    pub fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready(_))
+    }
+
+    /// Check if service is degraded
+    pub fn is_degraded(&self) -> bool {
+        matches!(self, Self::Degraded { .. })
+    }
+
+    /// Get service reference (ready or degraded fallback)
+    pub fn service(&self) -> Option<&T> {
+        match self {
+            Self::Ready(service) => Some(service),
+            Self::Degraded { fallback, .. } => Some(fallback),
+            Self::Unavailable { .. } => None,
+        }
+    }
+
+    /// Unwrap service or panic
+    pub fn unwrap(self) -> T {
+        match self {
+            Self::Ready(service) => service,
+            Self::Degraded { fallback, .. } => fallback,
+            Self::Unavailable { reason } => panic!("Service unavailable: {}", reason),
+        }
+    }
+
+    /// Convert to Result
+    pub fn into_result(self) -> Result<T> {
+        match self {
+            Self::Ready(service) => Ok(service),
+            Self::Degraded { fallback, .. } => Ok(fallback),
+            Self::Unavailable { reason } => anyhow::bail!("Service unavailable: {}", reason),
+        }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for ResolvedService<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Ready(service) => f.debug_tuple("Ready").field(service).finish(),
+            Self::Degraded { fallback, reason } => f
+                .debug_struct("Degraded")
+                .field("fallback", fallback)
+                .field("reason", reason)
+                .finish(),
+            Self::Unavailable { reason } => f
+                .debug_struct("Unavailable")
+                .field("reason", reason)
+                .finish(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    struct MockService {
+        #[allow(dead_code)]
+        name: String,
+    }
+
+    struct MockCustomService;
+
+    impl ServiceTrait for MockCustomService {
+        type Output = MockService;
+
+        fn name(&self) -> &str {
+            "mock-custom"
+        }
+
+        fn version(&self) -> &str {
+            "1.0.0"
+        }
+    }
+
+    #[test]
+    fn test_builtin_provider() {
+        let service = MockService {
+            name: "test".to_string(),
+        };
+        let provider = ServiceProvider::builtin(service);
+
+        assert_eq!(provider.kind(), ServiceProviderKind::Builtin);
+        assert!(provider.as_builtin().is_some());
+    }
+
+    #[test]
+    fn test_custom_provider() {
+        let provider: ServiceProvider<MockService> = ServiceProvider::custom(MockCustomService);
+
+        assert_eq!(provider.kind(), ServiceProviderKind::Custom);
+        assert!(provider.as_builtin().is_none());
+    }
+
+    #[test]
+    fn test_external_provider() {
+        let handle =
+            ExternalServiceHandle::new("test-module".to_string(), "/tmp/test.sock".to_string());
+        let provider: ServiceProvider<MockService> = ServiceProvider::external(handle);
+
+        assert_eq!(provider.kind(), ServiceProviderKind::External);
+    }
+
+    #[test]
+    fn test_resolved_service_ready() {
+        let service = MockService {
+            name: "test".to_string(),
+        };
+        let resolved = ResolvedService::Ready(service);
+
+        assert!(resolved.is_ready());
+        assert!(!resolved.is_degraded());
+        assert!(resolved.service().is_some());
+    }
+
+    #[test]
+    fn test_resolved_service_degraded() {
+        let fallback = MockService {
+            name: "fallback".to_string(),
+        };
+        let resolved = ResolvedService::Degraded {
+            fallback,
+            reason: "Primary failed".to_string(),
+        };
+
+        assert!(!resolved.is_ready());
+        assert!(resolved.is_degraded());
+        assert!(resolved.service().is_some());
+    }
+
+    #[test]
+    fn test_resolved_service_unavailable() {
+        let resolved: ResolvedService<MockService> = ResolvedService::Unavailable {
+            reason: "Not configured".to_string(),
+        };
+
+        assert!(!resolved.is_ready());
+        assert!(!resolved.is_degraded());
+        assert!(resolved.service().is_none());
+    }
+}

--- a/crates/impetus-core/tests/profile_tests.rs
+++ b/crates/impetus-core/tests/profile_tests.rs
@@ -1,0 +1,156 @@
+use impetus_core::{
+    Profile, ProfileConfig, ServiceBinding, ServiceBindings, ServiceProvider, ServiceProviderKind,
+};
+
+#[test]
+fn test_profile_defaults() {
+    assert_eq!(Profile::default(), Profile::Standard);
+
+    let standard = Profile::Standard.default_bindings();
+    assert_eq!(
+        standard.agent_loop,
+        ServiceBinding::Builtin("standard".to_string())
+    );
+
+    let minimal = Profile::Minimal.default_bindings();
+    assert_eq!(minimal.context, ServiceBinding::Disabled);
+    assert_eq!(minimal.memory, ServiceBinding::Disabled);
+}
+
+#[test]
+fn test_profile_config_resolution() {
+    let config = ProfileConfig {
+        profile: Profile::Standard,
+        services: Some(ServiceBindings {
+            agent_loop: ServiceBinding::Custom {
+                module_id: "my-agent-loop".to_string(),
+            },
+            context: ServiceBinding::External {
+                module_id: "custom-context".to_string(),
+            },
+            ..Profile::Standard.default_bindings()
+        }),
+    };
+
+    let resolved = config.resolve_bindings();
+
+    // Overridden services
+    assert_eq!(
+        resolved.agent_loop,
+        ServiceBinding::Custom {
+            module_id: "my-agent-loop".to_string()
+        }
+    );
+    assert_eq!(
+        resolved.context,
+        ServiceBinding::External {
+            module_id: "custom-context".to_string()
+        }
+    );
+
+    // Default services unchanged
+    assert_eq!(
+        resolved.scheduler,
+        ServiceBinding::Builtin("standard".to_string())
+    );
+}
+
+#[test]
+fn test_service_provider_kinds() {
+    #[derive(Debug, Clone)]
+    struct TestService;
+
+    let builtin = ServiceProvider::builtin(TestService);
+    assert_eq!(builtin.kind(), ServiceProviderKind::Builtin);
+    assert!(builtin.as_builtin().is_some());
+
+    let handle =
+        impetus_core::ExternalServiceHandle::new("test".to_string(), "/tmp/test.sock".to_string());
+    let external: ServiceProvider<TestService> = ServiceProvider::external(handle);
+    assert_eq!(external.kind(), ServiceProviderKind::External);
+    assert!(external.as_builtin().is_none());
+}
+
+#[test]
+fn test_resolved_service_states() {
+    #[derive(Debug, Clone)]
+    struct TestService {
+        #[allow(dead_code)]
+        name: String,
+    }
+
+    let ready = impetus_core::ResolvedService::Ready(TestService {
+        name: "primary".to_string(),
+    });
+    assert!(ready.is_ready());
+    assert!(!ready.is_degraded());
+    assert!(ready.service().is_some());
+
+    let degraded = impetus_core::ResolvedService::Degraded {
+        fallback: TestService {
+            name: "fallback".to_string(),
+        },
+        reason: "Primary unavailable".to_string(),
+    };
+    assert!(!degraded.is_ready());
+    assert!(degraded.is_degraded());
+    assert!(degraded.service().is_some());
+
+    let unavailable: impetus_core::ResolvedService<TestService> =
+        impetus_core::ResolvedService::Unavailable {
+            reason: "Not configured".to_string(),
+        };
+    assert!(!unavailable.is_ready());
+    assert!(!unavailable.is_degraded());
+    assert!(unavailable.service().is_none());
+}
+
+#[test]
+fn test_profile_descriptions() {
+    assert_eq!(
+        Profile::Standard.description(),
+        "Zero-config daily use with safe defaults"
+    );
+    assert_eq!(
+        Profile::Minimal.description(),
+        "Minimal runtime for debugging and benchmarks"
+    );
+    assert_eq!(
+        Profile::Creator.description(),
+        "Advanced customization and introspection enabled"
+    );
+}
+
+#[test]
+fn test_service_binding_serialization() {
+    let builtin = ServiceBinding::Builtin("standard".to_string());
+    let json = serde_json::to_string(&builtin).unwrap();
+    assert!(json.contains("builtin"));
+    assert!(json.contains("standard"));
+
+    let custom = ServiceBinding::Custom {
+        module_id: "my-module".to_string(),
+    };
+    let json = serde_json::to_string(&custom).unwrap();
+    assert!(json.contains("custom"));
+    assert!(json.contains("my-module"));
+
+    let disabled = ServiceBinding::Disabled;
+    let json = serde_json::to_string(&disabled).unwrap();
+    assert!(json.contains("disabled"));
+}
+
+#[test]
+fn test_profile_config_no_overrides() {
+    let config = ProfileConfig {
+        profile: Profile::Standard,
+        services: None,
+    };
+
+    let resolved = config.resolve_bindings();
+    let defaults = Profile::Standard.default_bindings();
+
+    assert_eq!(resolved.agent_loop, defaults.agent_loop);
+    assert_eq!(resolved.scheduler, defaults.scheduler);
+    assert_eq!(resolved.model_router, defaults.model_router);
+}

--- a/docs/KERNEL_INVARIANTS.md
+++ b/docs/KERNEL_INVARIANTS.md
@@ -1,0 +1,184 @@
+# Kernel Invariants
+
+**Impetus Kernel** defines non-bypassable security and execution boundaries.
+
+## Core Principle
+
+```
+Everything practical is replaceable.
+Kernel invariants are not bypassable.
+```
+
+Users may replace almost any service (AgentLoop, ModelRouter, Context, Tools, etc.), but **no custom provider can bypass the kernel pipeline.**
+
+## Non-Bypassable Pipeline
+
+Every action flows through this fixed sequence:
+
+```
+Action with origin (user | agent)
+         ↓
+   Policy admission
+         ↓
+Deny | Allow | NeedsApproval
+         ↓
+   [if NeedsApproval]
+   Human approval gate
+         ↓
+   Sandbox capability
+         ↓
+     Execution
+         ↓
+  Durable outcome/event
+```
+
+### 1. Action Origin
+
+Every action carries `origin: ActionOrigin`:
+
+```rust
+pub enum ActionOrigin {
+    User,    // Explicit user command
+    Agent,   // Model-generated action
+}
+```
+
+**Invariant:** A custom provider cannot forge `origin=User` to bypass policy.
+
+### 2. Policy Admission
+
+`PolicyEngine` evaluates every action before execution:
+
+```rust
+pub enum PolicyDecision {
+    Allow,
+    Deny { reason: String },
+    NeedsApproval { prompt: String },
+}
+```
+
+**Invariant:** Custom policy extensions may influence decisions within allowed bounds, but cannot bypass the admission gate entirely.
+
+### 3. Approval Resolver
+
+For `NeedsApproval` decisions, execution blocks until human input:
+
+```rust
+pub enum ApprovalResponse {
+    Approved,
+    Rejected,
+}
+```
+
+**Invariant:** No custom service can auto-approve or skip the human gate.
+
+### 4. Sandbox Capability
+
+Execution requires explicit capability grant from macOS Seatbelt sandbox:
+
+```rust
+pub enum SandboxProfile {
+    NoExecution,
+    ReadOnly,
+    WorkspaceWrite,
+    FullAccess,
+}
+```
+
+**Invariant:** Custom modules cannot escape sandbox boundaries or elevate privileges.
+
+### 5. Durable Outcome
+
+Every execution produces a durable event in SQLite WAL:
+
+```rust
+pub enum ActionOutcome {
+    Success { result: ActionResult },
+    Failure { error: String },
+    UnknownOutcome,  // Non-replayable failure
+}
+```
+
+**Invariant:** `UnknownOutcome` blocks retry for mutating operations. Custom providers cannot mark a failed mutating action as `Success` or replayable.
+
+### 6. Secrets Boundary
+
+Secrets live **only** in macOS Keychain:
+
+- Never in SQLite
+- Never in event logs
+- Never in tracing output
+- Never in JSON payloads to custom modules
+
+**Invariant:** Custom modules receive only reference tokens, never raw secrets.
+
+## Replaceable vs Non-Replaceable
+
+### Kernel Owns (Non-Replaceable)
+
+- Action origin enforcement
+- Policy admission gate
+- Approval resolver protocol
+- Sandbox enforcement
+- UnknownOutcome semantics
+- Secrets boundary
+- Durable event log integrity
+- Module isolation
+- IPC protocol compatibility
+
+### Services May Replace (Replaceable)
+
+- Policy decision logic (within admission framework)
+- AgentLoop strategy
+- Scheduler
+- ModelRouter
+- ContextService
+- ReferenceService
+- MemoryService
+- ToolProvider implementations
+- SearchBackend
+- BrowserProvider
+- CredentialResolver (reads Keychain references)
+- OutputReducer
+- RepoIntelligence
+
+## Custom Module Contract
+
+A custom module:
+
+**MAY:**
+- Implement service traits (AgentLoopStrategy, etc.)
+- Read/write through approved capabilities
+- Emit structured outputs
+- Request capabilities via module descriptor
+- Fail gracefully with fallback
+
+**MAY NOT:**
+- Bypass policy admission
+- Forge action origin
+- Auto-approve NeedsApproval
+- Access Keychain raw secrets
+- Escape sandbox boundaries
+- Rewrite durable outcome of failed mutating action
+- Skip IPC protocol negotiation
+
+## Enforcement
+
+- **Compile-time:** Trait bounds, type system
+- **Runtime:** Policy engine, sandbox profiles
+- **Process isolation:** External modules via Unix socket IPC
+- **Audit:** Event log immutability, secrets redaction
+
+## Violation Handling
+
+If a custom module attempts to bypass kernel invariants:
+
+1. **Detected at registration:** Module marked `Incompatible`, not loaded
+2. **Detected at runtime:** Module state → `Failed`, fallback to builtin (if safe), emit warning event
+3. **Detected in audit:** Security review flags for investigation
+
+## References
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md)
+- [VimTrap Implementation Plan](VimTrap_Implementation_Plan.md)
+- Issue #63

--- a/docs/VimTrap_Implementation_Plan.md
+++ b/docs/VimTrap_Implementation_Plan.md
@@ -1,0 +1,330 @@
+# VimTrap Implementation Plan
+
+**Issue:** #63  
+**Goal:** Maximum replaceability + Minimum required configuration
+
+## Current State
+
+Существующие компоненты:
+- `ModuleRegistry`: lifecycle, health, compatibility
+- `ServiceRegistry`: agent_loop, scheduler (partial)
+- `ModuleDescriptor`: id, kind, capabilities, permissions
+- Traits: `AgentLoopStrategy`, `AgentScheduler`
+- Module IPC, lifecycle, fallback policies
+
+**Gap:** нет явного разделения Kernel vs Replaceable Services, нет preset model, нет declarative binding.
+
+## Architecture Changes
+
+### 1. Kernel Invariants (non-replaceable)
+
+Фиксированный pipeline безопасности:
+
+```
+Action origin (user|agent)
+  ↓
+Policy admission
+  ↓
+Deny | Allow | NeedsApproval
+  ↓
+Sandbox capability
+  ↓
+Execution
+  ↓
+Durable outcome/event
+```
+
+**Kernel ownership:**
+- `PolicyEngine` admission logic
+- `ApprovalResolver` human gate
+- Secrets boundary (Keychain only)
+- `UnknownOutcome` semantics
+- Permission enforcement
+- Module isolation
+- Protocol compatibility
+
+**Non-negotiable:** custom provider не может bypass policy/sandbox/approval.
+
+### 2. Replaceable Services
+
+Target service contracts (постепенная миграция):
+
+```rust
+// Core services
+AgentLoopStrategy       ✓ exists
+AgentScheduler          ✓ exists
+ModelRouter             ○ planned
+ContextService          ○ planned
+ReferenceService        ○ planned
+MemoryService           ○ planned
+
+// Tool & execution
+ToolProvider            ○ planned (exists as ModuleKind)
+SearchBackend           ✓ exists (ModuleKind)
+BrowserProvider         ✓ exists (ModuleKind)
+
+// Security & policy
+CredentialResolver      ✓ exists (ModuleKind)
+PolicyExtension         ✓ exists (ModuleKind)
+
+// Output & intelligence
+OutputReducer           ○ planned
+RepoIntelligence        ○ planned
+```
+
+### 3. Provider Model
+
+Слой абстракции для consumer:
+
+```rust
+pub enum ServiceProvider<T> {
+    Builtin(T),
+    Custom(Box<dyn ServiceTrait>),
+    External(ExternalModuleHandle),
+}
+
+// Consumer depends on trait, not concrete impl
+impl Harness {
+    context_service: ServiceProvider<ContextService>,
+    model_router: ServiceProvider<ModelRouter>,
+    // ...
+}
+```
+
+**Принцип:** `AgentLoop` зависит от `ContextService` trait, не от `BuiltinContextOptimizer`.
+
+### 4. Profile System
+
+Три preset режима:
+
+#### Standard (default)
+```yaml
+# zero-config, implicit
+agent_loop: builtin
+scheduler: builtin
+model_router: balanced
+context: builtin-lazy
+references: yaml
+memory: builtin
+policy: standard
+tools: builtin
+output_reducer: builtin
+```
+
+Команда: `impetus` — запускается без конфигурации.
+
+#### Minimal
+```yaml
+# debugging, benchmarks, tests
+agent_loop: minimal
+scheduler: sync
+model_router: direct
+context: disabled
+references: disabled
+memory: disabled
+policy: permissive
+tools: minimal
+```
+
+Команда: `impetus --profile minimal`
+
+#### Creator
+```yaml
+# advanced customization visible
+# service replacement enabled
+# introspection tools active
+```
+
+Команда: `impetus --profile creator`
+
+### 5. Declarative Service Binding
+
+Пользователь может override в `~/.config/impetus/config.yaml`:
+
+```yaml
+profile: standard
+
+services:
+  context: my-context-provider  # custom provider
+  model_router: local-first     # builtin variant
+  reference: company-ref        # external module
+
+modules:
+  my-context-provider:
+    path: ~/.impetus/modules/my-context
+    permissions:
+      filesystem: [read]
+```
+
+Или для project-local override в `.impetus/config.yaml`.
+
+### 6. Progressive Disclosure
+
+Standard mode UI (minimal surface):
+```
+Model: claude-3.5-sonnet
+Mode: standard
+Session: abc123
+Usage: 45K tokens
+```
+
+Creator mode UI (introspection):
+```
+Profile: creator
+Providers:
+  ContextService    → builtin-context
+  ReferenceService  → yaml-reference
+  ModelRouter       → balanced-router
+  ToolProvider      → builtin-tools
+
+Modules: 3 loaded, 1 degraded
+Health: OK
+```
+
+### 7. Anti-Pattern: Hook Hell
+
+**Запрещено:**
+```rust
+// Bad: hook accumulation
+before_prompt, after_prompt,
+before_model, after_model,
+before_tool, after_tool,
+before_context, after_context,
+...
+```
+
+**Правильно:**
+```rust
+// Good: service replacement
+impl ContextService for MyContextService {
+    async fn optimize(&self, context: Context) -> Result<Context> {
+        // Full control over logic
+    }
+}
+```
+
+Hooks допустимы только для proven use case, который невозможно выразить через service contract.
+
+### 8. Fallback & Health
+
+Использовать существующие механизмы:
+- `ModuleState`: Degraded, Failed
+- `FallbackPolicy`: FailFast, Retry, Alternate, Degrade, SafeDefault
+- `CapabilityProbe`
+- `ModuleHealth`
+
+Пример:
+```
+custom ContextService failed
+  ↓
+fallback → builtin ContextService (if replay-safe)
+  ↓
+emit warning, continue with degraded state
+```
+
+Для non-replayable operations: соблюдать `UnknownOutcome`.
+
+### 9. Introspection
+
+Расширить существующий `impetus components`:
+
+```bash
+impetus components list         # existing
+impetus components status       # existing
+impetus profile show            # planned
+impetus components bindings     # planned
+```
+
+Output для `bindings`:
+```
+ContextService     → builtin-context (v0.1.0)
+ReferenceService   → yaml-reference (v0.1.0)
+ModelRouter        → balanced-router (v0.1.0)
+ToolProvider       → builtin-tools (v0.1.0)
+SearchBackend      → builtin-search (v0.1.0)
+```
+
+## Implementation Phases
+
+### Phase 1: Foundation (this PR)
+
+1. **Документация границ:**
+   - Создать `docs/KERNEL_INVARIANTS.md`
+   - Зафиксировать non-bypassable pipeline
+   - Обновить ARCHITECTURE.md
+
+2. **Profile model:**
+   - Добавить `ProfileDescriptor` enum: Standard | Minimal | Creator
+   - Добавить `ProfileConfig` struct с service bindings
+   - Loader для profile из config
+
+3. **Service provider abstraction:**
+   - Обобщить `ServiceProvider<T>` enum
+   - Миграция одного существующего service как proof (AgentLoopStrategy?)
+
+4. **Declarative binding:**
+   - Парсинг `services:` section из config
+   - Связывание builtin/custom/external providers
+
+5. **Introspection:**
+   - `impetus profile show` command
+   - `impetus components bindings` command
+
+6. **Tests:**
+   - Profile loading & resolution
+   - Service provider selection
+   - Fallback when custom provider fails
+
+7. **Documentation:**
+   - Update ARCHITECTURE.md
+   - Update ROADMAP.md
+   - Add VimTrap principle to docs
+
+### Phase 2+: Incremental Migration (future PRs)
+
+- Migrate existing services к provider model
+- Expand service contracts (ModelRouter, Context, Memory, etc)
+- Enhanced introspection UI
+- Creator mode tooling
+
+## Success Criteria
+
+После Phase 1:
+
+**Обычный пользователь:**
+```bash
+impetus  # zero-config, просто работает
+```
+
+**Продвинутый пользователь:**
+```bash
+impetus --profile creator
+impetus profile show
+impetus components bindings
+
+# declarative override в ~/.config/impetus/config.yaml
+```
+
+**Architecture:**
+- Kernel invariants явно зафиксированы
+- Хотя бы один service через provider model
+- Profile system работает
+- Introspection commands работают
+- Tests покрывают основные сценарии
+
+## Non-Goals (не в этом PR)
+
+- Полная миграция всех services
+- Marketplace/registry
+- Dynamic ABI/scripting
+- Сотни hooks
+- GUI editor
+- Сложный dependency solver
+
+## References
+
+- Issue #63
+- VimTrap.md
+- ARCHITECTURE.md
+- TODO.md
+- docs/ROADMAP.md


### PR DESCRIPTION
Implement Phase 1 of VimTrap architecture: maximum replaceability with
minimum required configuration.

Core changes:
- Profile system: Standard/Minimal/Creator presets with zero-config defaults
- Service provider abstraction: ServiceProvider<T> for builtin/custom/external
- Kernel invariants documentation: non-bypassable security pipeline
- CLI introspection: 'impetus profile show' and 'impetus components bindings'
- Service binding model: declarative replacement of agent loop, scheduler, etc.

Architecture:
- Kernel owns: policy admission, approval gate, sandbox, secrets boundary
- Replaceable services: AgentLoop, Scheduler, ModelRouter, Context, Memory, etc.
- Default > configuration: builtin defaults for all services
- Progressive disclosure: modularity deep inside, not in user's face

Tests:
- Profile resolution with overrides
- Service provider kinds and lifecycle
- Resolved service states (Ready/Degraded/Unavailable)

Documentation:
- docs/KERNEL_INVARIANTS.md: non-bypassable boundaries
- docs/VimTrap_Implementation_Plan.md: full architectural plan
- ARCHITECTURE.md: updated with Phase 3.5

Success criteria met:
- Zero-config 'impetus' works with safe defaults
- Advanced users can replace services declaratively
- Kernel invariants explicitly fixed and documented
