### PR TITLE
refactor: rename escalation to fallback in model router (closes #68)

### DIFF
--- a/crates/impetus-core/src/model_router.rs
+++ b/crates/impetus-core/src/model_router.rs
@@ -124,9 +124,9 @@ pub struct ModelRouterConfig {
     #[serde(default)]
     pub models: Vec<ModelMetadata>,
 
-    /// Escalation chain for retries
+    /// Fallback chain for technical failures (model unavailable, rate limit, etc.)
     #[serde(default)]
-    pub escalation_chain: Vec<String>,
+    pub fallback_chain: Vec<String>,
 }
 
 /// Model router for intelligent model selection
@@ -242,15 +242,15 @@ impl ModelRouter {
         score
     }
 
-    /// Get escalation model after failure
-    pub fn escalate(&self, current_model: &str) -> Option<ModelSelection> {
+    /// Get fallback model after technical failure
+    pub fn fallback(&self, current_model: &str) -> Option<ModelSelection> {
         let current_idx = self
             .config
-            .escalation_chain
+            .fallback_chain
             .iter()
             .position(|m| m == current_model)?;
 
-        let next_model_id = self.config.escalation_chain.get(current_idx + 1)?;
+        let next_model_id = self.config.fallback_chain.get(current_idx + 1)?;
         let next_model = self
             .config
             .models
@@ -260,7 +260,7 @@ impl ModelRouter {
         Some(ModelSelection {
             provider_id: next_model.provider_id.clone(),
             model_id: next_model.model_id.clone(),
-            reasoning: format!("Escalated from {}", current_model),
+            reasoning: format!("Fallback from {}", current_model),
         })
     }
 }
@@ -316,7 +316,7 @@ mod tests {
         let config = ModelRouterConfig {
             policy: RouterPolicy::LocalFirst,
             models: vec![mock_local_model(), mock_cloud_model()],
-            escalation_chain: vec![],
+            fallback_chain: vec![],
         };
         let router = ModelRouter::new(config);
 
@@ -336,7 +336,7 @@ mod tests {
         let config = ModelRouterConfig {
             policy: RouterPolicy::QualityFirst,
             models: vec![mock_local_model(), mock_cloud_model()],
-            escalation_chain: vec![],
+            fallback_chain: vec![],
         };
         let router = ModelRouter::new(config);
 
@@ -356,7 +356,7 @@ mod tests {
         let config = ModelRouterConfig {
             policy: RouterPolicy::Balanced,
             models: vec![mock_local_model()],
-            escalation_chain: vec![],
+            fallback_chain: vec![],
         };
         let router = ModelRouter::new(config);
 
@@ -370,16 +370,16 @@ mod tests {
     }
 
     #[test]
-    fn escalation_chain_works() {
+    fn fallback_chain_works() {
         let config = ModelRouterConfig {
             policy: RouterPolicy::Balanced,
             models: vec![mock_local_model(), mock_cloud_model()],
-            escalation_chain: vec!["llama3:8b".to_string(), "gpt-4".to_string()],
+            fallback_chain: vec!["llama3:8b".to_string(), "gpt-4".to_string()],
         };
         let router = ModelRouter::new(config);
 
-        let escalated = router.escalate("llama3:8b").unwrap();
-        assert_eq!(escalated.model_id, "gpt-4");
+        let fallback = router.fallback("llama3:8b").unwrap();
+        assert_eq!(fallback.model_id, "gpt-4");
     }
 
     #[test]

--- a/crates/impetus-core/tests/budget_router_integration.rs
+++ b/crates/impetus-core/tests/budget_router_integration.rs
@@ -86,7 +86,7 @@ fn model_router_selects_by_policy() {
     let config = ModelRouterConfig {
         policy: RouterPolicy::LocalFirst,
         models: vec![local_model.clone(), cloud_model.clone()],
-        escalation_chain: vec![],
+        fallback_chain: vec![],
     };
     let router = ModelRouter::new(config);
 
@@ -104,7 +104,7 @@ fn model_router_selects_by_policy() {
     let config = ModelRouterConfig {
         policy: RouterPolicy::QualityFirst,
         models: vec![local_model.clone(), cloud_model.clone()],
-        escalation_chain: vec![],
+        fallback_chain: vec![],
     };
     let router = ModelRouter::new(config);
 
@@ -214,7 +214,7 @@ fn vertical_slice_budget_router_integration() {
     let router_config = ModelRouterConfig {
         policy: RouterPolicy::LocalFirst,
         models,
-        escalation_chain: vec!["llama3:8b".to_string(), "gpt-4o".to_string()],
+        fallback_chain: vec!["llama3:8b".to_string(), "gpt-4o".to_string()],
     };
     let router = ModelRouter::new(router_config);
 
@@ -248,9 +248,9 @@ fn vertical_slice_budget_router_integration() {
     runtime.record_turn(4000).unwrap();
     assert_eq!(runtime.budget_state().unwrap().tokens_used, 9000);
 
-    // Escalate if local model fails
-    let escalated = router.escalate("llama3:8b").unwrap();
-    assert_eq!(escalated.model_id, "gpt-4o");
+    // Fallback if local model fails (technical failure: unavailable, rate limit, etc.)
+    let fallback = router.fallback("llama3:8b").unwrap();
+    assert_eq!(fallback.model_id, "gpt-4o");
 
     // Budget state persisted in runtime
     let state = runtime.budget_state().unwrap();

--- a/docs/REFERENCE_STORE.md
+++ b/docs/REFERENCE_STORE.md
@@ -218,15 +218,15 @@ Datasets have sensitivity levels:
 - **Internal**: Organization-only
 - **Private**: User-only, not sent to cloud models by default
 
-The agent respects sensitivity when escalating to cloud models:
+The agent respects sensitivity when routing to models:
 
 ```rust
 match dataset.sensitivity {
     Sensitivity::Private => {
-        // Only use with local models or sanitized cloud requests
+        // Only use with local models by default
     }
     Sensitivity::Internal => {
-        // Organization-approved cloud models only
+        // Organization-approved models only
     }
     Sensitivity::Public => {
         // Any model

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -82,10 +82,10 @@ remaining tool families.
 
 **Current:** provider abstraction, registry foundation, direct provider path.
 
-**Target:** route by complexity, capability, health, cost, latency, privacy,
+**Target:** route by capability, health, cost, latency, privacy,
 context, prompt cache, budget, reasoning. Policies: `local-first`, `free-first`,
-`balanced`, `quality-first`. Escalation light/local → strong/cloud через
-minimal sanitised request; sensitive repo context не уходит в облако по умолчанию.
+`balanced`, `quality-first`. Technical fallback between providers when unavailable.
+Sensitive repo context не уходит в облако по умолчанию.
 
 ### Durable budgets
 


### PR DESCRIPTION
Replace 'escalation' terminology with 'fallback' to clarify that this
mechanism handles technical failures (unavailable model, rate limit)
rather than semantic escalation based on task complexity.

Changes:
- ModelRouterConfig: escalation_chain → fallback_chain
- ModelRouter: escalate() → fallback()
- Update docs to remove complexity-based escalation references
- Clarify that fallback is for technical failures only
