### PR TITLE
feat: integrate ModelRouter into production Prompt path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ __pycache__/
 /site/dist/
 /site/node_modules/
 /docs/superpowers/
+*.zip

--- a/crates/impetus-core/src/harness_api.rs
+++ b/crates/impetus-core/src/harness_api.rs
@@ -13,6 +13,7 @@ use crate::{
     MockProvider, NoCredentialResolver, OpenAiCompatibleAdapter, OpenAiCompatibleProvider,
     PolicyEngine, ProviderMessage, ProviderRegistry, ReadOnlyTool, ReadOnlyToolKind, ReadOnlyTools,
     ResolveRequest, RuntimeError, RuntimeStatus, Sandbox, SandboxScope, ToolOutcome,
+    model_router::{ModelRouter, ModelRouterConfig},
 };
 use anyhow::Result;
 use std::collections::HashMap;
@@ -52,6 +53,7 @@ pub struct Harness {
     policy: PolicyEngine,
     provider_registry: ProviderRegistry,
     default_provider_id: String,
+    model_router: ModelRouter,
     credential_resolver: Arc<dyn CredentialResolver>,
     cancellations: Arc<Mutex<HashMap<uuid::Uuid, CancellationToken>>>,
     workspace_root: PathBuf,
@@ -68,11 +70,14 @@ impl Harness {
         registry
             .register(mock)
             .expect("failed to register mock provider");
+        let router_config = ModelRouterConfig::default();
+        let model_router = ModelRouter::new(router_config);
         Self {
             store,
             policy,
             provider_registry: registry,
             default_provider_id: "mock".to_string(),
+            model_router,
             credential_resolver: Arc::new(NoCredentialResolver),
             cancellations: Arc::new(Mutex::new(HashMap::new())),
             workspace_root,
@@ -93,11 +98,14 @@ impl Harness {
         registry
             .register(provider)
             .expect("failed to register test provider");
+        let router_config = ModelRouterConfig::default();
+        let model_router = ModelRouter::new(router_config);
         Self {
             store,
             policy,
             provider_registry: registry,
             default_provider_id,
+            model_router,
             credential_resolver: Arc::new(NoCredentialResolver),
             cancellations: Arc::new(Mutex::new(HashMap::new())),
             workspace_root,
@@ -148,11 +156,15 @@ impl Harness {
             .register(adapter)
             .expect("failed to register openai provider");
 
+        let router_config = ModelRouterConfig::default();
+        let model_router = ModelRouter::new(router_config);
+
         Self {
             store,
             policy,
             provider_registry: registry,
             default_provider_id: provider_id,
+            model_router,
             credential_resolver,
             cancellations: Arc::new(Mutex::new(HashMap::new())),
             workspace_root,
@@ -193,11 +205,15 @@ impl Harness {
             .register(adapter)
             .expect("failed to register acp gateway");
 
+        let router_config = ModelRouterConfig::default();
+        let model_router = ModelRouter::new(router_config);
+
         Self {
             store,
             policy,
             provider_registry: registry,
             default_provider_id: provider_id,
+            model_router,
             credential_resolver: Arc::new(NoCredentialResolver),
             cancellations: Arc::new(Mutex::new(HashMap::new())),
             workspace_root,
@@ -228,6 +244,7 @@ impl Harness {
             self.policy.clone(),
             self.provider_registry.clone(),
             self.default_provider_id.clone(),
+            self.model_router.clone(),
             self.credential_resolver.clone(),
             self.cancellations.clone(),
             self.workspace_root.clone(),
@@ -244,6 +261,7 @@ fn handle_request(
     policy: PolicyEngine,
     provider_registry: ProviderRegistry,
     default_provider_id: String,
+    model_router: ModelRouter,
     credential_resolver: Arc<dyn CredentialResolver>,
     cancellations: Arc<Mutex<HashMap<uuid::Uuid, CancellationToken>>>,
     workspace_root: PathBuf,
@@ -337,6 +355,38 @@ fn handle_request(
                         )]
                     });
                 let runtime_session_id = runtime.session_id();
+
+                // Select model through router
+                let requirements = crate::model_router::CapabilityRequirements {
+                    tools: true,
+                    ..Default::default()
+                };
+                let budget = runtime.budget_config().unwrap_or_default();
+                let selected = model_router.select_model(&requirements, &budget);
+
+                let selected_provider_id = selected
+                    .as_ref()
+                    .map(|s| s.provider_id.clone())
+                    .unwrap_or_else(|| default_provider_id.clone());
+
+                // Record selection decision
+                let selection_message = if let Some(ref selection) = selected {
+                    format!(
+                        "ModelRouter selected {}/{}: {}",
+                        selection.provider_id, selection.model_id, selection.reasoning
+                    )
+                } else {
+                    format!(
+                        "ModelRouter fallback to default provider: {}",
+                        selected_provider_id
+                    )
+                };
+                let _ = runtime.append_event(crate::EventPayload::Notice(
+                    crate::NoticeEvent::Runtime {
+                        message: selection_message,
+                    },
+                ));
+
                 let task_runtime = runtime.clone();
                 let cancellation = CancellationToken::new();
                 if let Ok(mut active) = cancellations.lock() {
@@ -344,14 +394,13 @@ fn handle_request(
                 }
                 let task_cancellations = cancellations.clone();
                 let task_provider_registry = provider_registry.clone();
-                let task_default_provider_id = default_provider_id.clone();
                 let task_credential_resolver = credential_resolver.clone();
                 tokio::spawn(async move {
                     run_agent_loop(
                         task_runtime,
                         run_id,
                         task_provider_registry,
-                        task_default_provider_id,
+                        selected_provider_id,
                         task_credential_resolver,
                         provider_messages,
                         cancellation,

--- a/crates/impetus-core/src/model_router.rs
+++ b/crates/impetus-core/src/model_router.rs
@@ -130,6 +130,7 @@ pub struct ModelRouterConfig {
 }
 
 /// Model router for intelligent model selection
+#[derive(Clone)]
 pub struct ModelRouter {
     config: ModelRouterConfig,
 }

--- a/crates/impetus-core/src/runtime.rs
+++ b/crates/impetus-core/src/runtime.rs
@@ -180,6 +180,13 @@ impl AgentRuntime {
         self.budget.clone()
     }
 
+    /// Get the current budget configuration if budget is set
+    pub fn budget_config(&self) -> Option<BudgetConfig> {
+        self.budget
+            .as_ref()
+            .map(|checker| checker.lock().unwrap().config().clone())
+    }
+
     /// Check if budget allows this request
     pub fn check_budget(&self, estimated_tokens: u64) -> Result<(), crate::budget::BudgetError> {
         if let Some(ref checker) = self.budget {
@@ -403,6 +410,12 @@ impl AgentRuntime {
 
     pub fn events(&self) -> Result<Vec<Event>, RuntimeError> {
         Ok(self.store.list(self.session_id)?)
+    }
+
+    /// Append an event to the session event log
+    pub fn append_event(&self, payload: EventPayload) -> Result<(), RuntimeError> {
+        self.store.append_next(self.session_id, payload)?;
+        Ok(())
     }
 
     pub fn status(&self) -> Result<RuntimeStatus, RuntimeError> {

--- a/crates/impetus-core/tests/model_router_prompt_integration.rs
+++ b/crates/impetus-core/tests/model_router_prompt_integration.rs
@@ -1,0 +1,155 @@
+//! Integration test: ModelRouter is called during production Prompt path
+//!
+//! Verifies that the ModelRouter is actually invoked when a prompt is submitted,
+//! and that the selection decision is recorded in durable events.
+
+use impetus_core::{
+    AgentRuntime, EventPayload, Harness, IpcRequest, IpcResponse, PolicyEngine, RuntimeStatus,
+    budget::BudgetConfig,
+    model_router::{
+        CapabilityRequirements, ModelCapabilities, ModelMetadata, ModelRouter, ModelRouterConfig,
+        RouterPolicy,
+    },
+    policy::SandboxScope,
+    storage::MemoryEventStore,
+};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn model_router_selects_provider_on_prompt() {
+    let store = Arc::new(MemoryEventStore::default());
+    let workspace_root = std::env::current_dir().unwrap();
+    let policy = PolicyEngine::new(SandboxScope::local_workspace(&workspace_root));
+    let harness = Harness::new(store.clone(), policy.clone());
+
+    // Create session
+    let response = harness.handle(IpcRequest::CreateSession {
+        workspace_root: workspace_root.clone(),
+    });
+    let session_id = match response {
+        IpcResponse::Session { session_id, .. } => session_id,
+        other => panic!("Expected Session response, got {:?}", other),
+    };
+
+    // Submit prompt
+    let response = harness.handle(IpcRequest::Prompt {
+        session_id,
+        text: "test prompt".to_string(),
+    });
+    assert!(matches!(response, IpcResponse::Status { .. }));
+
+    // Wait a bit for async task to append events
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Check events for ModelRouter selection notice
+    let runtime = AgentRuntime::attach(store, policy, session_id).unwrap();
+    let events = runtime.events().unwrap();
+
+    let has_router_notice = events.iter().any(|event| {
+        matches!(
+            &event.payload,
+            EventPayload::Notice(impetus_core::NoticeEvent::Runtime { message })
+            if message.contains("ModelRouter selected") || message.contains("ModelRouter fallback")
+        )
+    });
+
+    assert!(
+        has_router_notice,
+        "Expected ModelRouter selection or fallback notice in events. Found {} events total",
+        events.len()
+    );
+}
+
+#[tokio::test]
+async fn model_router_falls_back_to_default_when_no_models_configured() {
+    let store = Arc::new(MemoryEventStore::default());
+    let workspace_root = std::env::current_dir().unwrap();
+    let policy = PolicyEngine::new(SandboxScope::local_workspace(&workspace_root));
+
+    // Harness with empty router config
+    let harness = Harness::new(store.clone(), policy.clone());
+
+    let response = harness.handle(IpcRequest::CreateSession {
+        workspace_root: workspace_root.clone(),
+    });
+    let session_id = match response {
+        IpcResponse::Session { session_id, .. } => session_id,
+        other => panic!("Expected Session response, got {:?}", other),
+    };
+
+    // Submit prompt - should fallback to default_provider_id (mock)
+    let response = harness.handle(IpcRequest::Prompt {
+        session_id,
+        text: "test prompt".to_string(),
+    });
+
+    // Should not fail even with empty router
+    assert!(matches!(
+        response,
+        IpcResponse::Status {
+            status: RuntimeStatus::Running,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn model_router_config_uses_balanced_policy_by_default() {
+    let config = ModelRouterConfig::default();
+    assert_eq!(config.policy, RouterPolicy::Balanced);
+}
+
+#[test]
+fn model_router_selection_respects_capability_requirements() {
+    let tool_model = ModelMetadata {
+        provider_id: "provider-a".to_string(),
+        model_id: "tool-model".to_string(),
+        capabilities: ModelCapabilities {
+            tools: true,
+            reasoning: false,
+            vision: false,
+            context_window: 8192,
+        },
+        cost_per_mtok: Some((1.0, 2.0)),
+        is_local: false,
+        avg_latency_ms: Some(500),
+        health: 1.0,
+    };
+
+    let no_tool_model = ModelMetadata {
+        provider_id: "provider-b".to_string(),
+        model_id: "no-tool-model".to_string(),
+        capabilities: ModelCapabilities {
+            tools: false,
+            reasoning: true,
+            vision: false,
+            context_window: 16384,
+        },
+        cost_per_mtok: Some((0.5, 1.0)),
+        is_local: false,
+        avg_latency_ms: Some(300),
+        health: 1.0,
+    };
+
+    let config = ModelRouterConfig {
+        policy: RouterPolicy::Balanced,
+        models: vec![tool_model.clone(), no_tool_model.clone()],
+        fallback_chain: vec![],
+    };
+
+    let router = ModelRouter::new(config);
+
+    // Require tools capability
+    let requirements = CapabilityRequirements {
+        tools: true,
+        ..Default::default()
+    };
+
+    let selection = router
+        .select_model(&requirements, &BudgetConfig::default())
+        .expect("Should select a model");
+
+    // Must select the tool-capable model
+    assert_eq!(selection.provider_id, "provider-a");
+    assert_eq!(selection.model_id, "tool-model");
+}


### PR DESCRIPTION
Closes #6

## Changes
- ModelRouter.select_model() called on every Prompt before provider dispatch
- Selection decision (or fallback) recorded as durable Notice event
- Added Clone derive for ModelRouter and ModelRouterConfig
- Runtime.append_event() method for recording post-session-creation notices
- Integration test verifies router is invoked and events are persisted
- Fallback to default provider when no models configured

## Testing
- All existing tests pass (355 unit tests)
- New integration test: model_router_prompt_integration
- Verified with task verify (fmt, test, check, clippy)

Task 06 from impetus_next_prompts complete.