### PR TITLE
feat: implement provider-native structured tool calls

### DIFF
--- a/crates/impetus-core/src/acp_adapter.rs
+++ b/crates/impetus-core/src/acp_adapter.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     Action, ActionKind, ActionOrigin, ModelProvider, PolicyDecision, PolicyEngine, ProviderError,
-    ProviderHealth, ProviderMessage,
+    ProviderHealth, ProviderMessage, StreamEvent,
 };
 use agent_client_protocol::AcpAgentConfig;
 use async_trait::async_trait;
@@ -98,7 +98,7 @@ impl ModelProvider for AcpAdapter {
         _credential: Option<&str>,
         _runtime: Option<Arc<crate::AgentRuntime>>,
         cancel: CancellationToken,
-        mut on_chunk: Box<dyn FnMut(String) -> Result<(), ProviderError> + Send>,
+        mut on_event: Box<dyn FnMut(StreamEvent) -> Result<(), ProviderError> + Send>,
     ) -> Result<(), ProviderError> {
         // Проверяем состояние
         let state = self.gateway.state().await;
@@ -143,8 +143,8 @@ impl ModelProvider for AcpAdapter {
                     match update {
                         Some(StreamUpdate::Text(text)) => {
                             debug!("Received text chunk: {} chars", text.len());
-                            on_chunk(text).map_err(|e| {
-                                error!("Chunk callback failed: {:?}", e);
+                            on_event(StreamEvent::TextDelta { delta: text }).map_err(|e| {
+                                error!("Event callback failed: {:?}", e);
                                 e
                             })?;
                         }

--- a/crates/impetus-core/src/agent_loop.rs
+++ b/crates/impetus-core/src/agent_loop.rs
@@ -5,8 +5,9 @@
 //! observation feeding back into the next model turn.
 
 use crate::{
-    AgentRuntime, BudgetError, EventPayload, ModelProvider, PolicyEngine, ProviderError,
-    ProviderMessage, RetryEvent, RuntimeError, RuntimeStatus, ToolOrchestrator,
+    AgentRuntime, BudgetError, EventPayload, FinishReason, ModelProvider, PolicyEngine,
+    ProviderError, ProviderMessage, RetryEvent, RuntimeError, RuntimeStatus, StreamEvent,
+    ToolOrchestrator,
 };
 use std::sync::Arc;
 use thiserror::Error;
@@ -109,16 +110,16 @@ impl AgentLoop {
             iteration += 1;
 
             // Phase 1: Model inference with retry logic
-            let model_response = self
+            let turn_result = self
                 .call_model_with_retry(run_id, &provider, &messages, &cancellation)
                 .await?;
 
-            // Phase 2: Extract tool calls from response
-            let tool_calls = self.extract_tool_calls(&model_response);
+            // Phase 2: Tool calls are already extracted from StreamEvents
+            let tool_calls = turn_result.tool_calls;
 
             if tool_calls.is_empty() {
                 // No more tool calls — agent loop complete
-                self.runtime.record_agent_final(run_id, model_response)?;
+                self.runtime.record_agent_final(run_id, turn_result.text)?;
                 return Ok(());
             }
 
@@ -131,7 +132,7 @@ impl AgentLoop {
             // Phase 4: Add observations to message history for next turn
             // Note: Using 'user' role for observations as assistant/tool_result
             // roles are not yet implemented in ProviderMessage
-            messages.push(ProviderMessage::assistant(model_response));
+            messages.push(ProviderMessage::assistant(turn_result.text));
             for observation in observations {
                 messages.push(ProviderMessage::tool(
                     serde_json::to_string(&observation)
@@ -147,7 +148,7 @@ impl AgentLoop {
         provider: &Arc<dyn ModelProvider>,
         messages: &[ProviderMessage],
         cancellation: &CancellationToken,
-    ) -> Result<String, AgentLoopError> {
+    ) -> Result<ModelTurnResult, AgentLoopError> {
         let mut attempt = 0;
 
         loop {
@@ -215,7 +216,7 @@ impl AgentLoop {
         provider: &Arc<dyn ModelProvider>,
         messages: &[ProviderMessage],
         cancellation: &CancellationToken,
-    ) -> Result<String, AgentLoopError> {
+    ) -> Result<ModelTurnResult, AgentLoopError> {
         // Check runtime status before calling model
         if !matches!(self.runtime.status(), Ok(RuntimeStatus::Running)) {
             return Err(AgentLoopError::Runtime(RuntimeError::InactiveRun(run_id)));
@@ -228,7 +229,7 @@ impl AgentLoop {
             return Err(AgentLoopError::Budget(budget_error));
         }
 
-        let accumulated = Arc::new(std::sync::Mutex::new(String::new()));
+        let accumulator = Arc::new(std::sync::Mutex::new(TurnAccumulator::default()));
         let runtime = self.runtime.clone();
         let chunk_id = Arc::new(std::sync::Mutex::new(
             self.runtime
@@ -245,7 +246,7 @@ impl AgentLoop {
                 })
                 .unwrap_or(1),
         ));
-        let accumulated_clone = accumulated.clone();
+        let accumulator_clone = accumulator.clone();
 
         provider
             .stream_messages(
@@ -253,28 +254,68 @@ impl AgentLoop {
                 None, // credential resolution handled at provider level
                 Some(self.runtime.clone()),
                 cancellation.clone(),
-                Box::new(move |chunk| {
-                    let id = {
-                        let mut counter = chunk_id.lock().unwrap();
-                        let id = *counter;
-                        *counter += 1;
-                        id
-                    };
-                    runtime
-                        .record_agent_chunk(run_id, id, chunk.clone())
-                        .map(|_| ())
-                        .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
-                    accumulated_clone.lock().unwrap().push_str(&chunk);
+                Box::new(move |event| {
+                    match event {
+                        StreamEvent::TextDelta { delta } => {
+                            let id = {
+                                let mut counter = chunk_id.lock().unwrap();
+                                let id = *counter;
+                                *counter += 1;
+                                id
+                            };
+                            runtime
+                                .record_agent_chunk(run_id, id, delta.clone())
+                                .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+                            // Lock only for mutation
+                            accumulator_clone.lock().unwrap().text.push_str(&delta);
+                        }
+                        StreamEvent::ToolCall {
+                            id,
+                            name,
+                            arguments,
+                        } => {
+                            accumulator_clone.lock().unwrap().tool_calls.push(ToolCall {
+                                id,
+                                name,
+                                arguments,
+                            });
+                        }
+                        StreamEvent::Usage {
+                            prompt_tokens,
+                            completion_tokens,
+                            measured,
+                        } => {
+                            accumulator_clone.lock().unwrap().usage =
+                                Some((prompt_tokens, completion_tokens, measured));
+                        }
+                        StreamEvent::Finish { reason } => {
+                            accumulator_clone.lock().unwrap().finish_reason = Some(reason);
+                        }
+                        StreamEvent::Reasoning { .. } => {
+                            // Future: record reasoning traces
+                        }
+                    }
                     Ok(())
                 }),
             )
             .await?;
 
-        let result = accumulated.lock().unwrap().clone();
+        let acc = accumulator.lock().unwrap();
+        let text = acc.text.clone();
+        let tool_calls = acc.tool_calls.clone();
+        let measured_usage = acc
+            .usage
+            .filter(|(_, _, measured)| *measured)
+            .map(|(p, c, _)| (p, c));
 
-        // Record turn completion with actual token usage
-        let actual_tokens = self.estimate_response_tokens(&result);
-        self.runtime.record_turn(estimated_tokens + actual_tokens)?;
+        // Record turn completion with token usage
+        let tokens_used = if let Some((prompt, completion)) = measured_usage {
+            prompt + completion
+        } else {
+            // Fallback to estimation if provider didn't send usage
+            estimated_tokens + self.estimate_response_tokens(&text)
+        };
+        self.runtime.record_turn(tokens_used)?;
 
         // Emit budget update event
         if let Some(state) = self.runtime.budget_state() {
@@ -304,73 +345,14 @@ impl AgentLoop {
             }
         }
 
-        Ok(result)
+        Ok(ModelTurnResult {
+            text,
+            tool_calls,
+            measured_usage,
+        })
     }
 
-    fn extract_tool_calls(&self, response: &str) -> Vec<ToolCall> {
-        // Simple XML-style tool call parser for Anthropic/Claude format:
-        // <tool_use>
-        // <tool_name>name</tool_name>
-        // <parameters>{...}</parameters>
-        // </tool_use>
-        //
-        // This is a minimal parser, not a full XML implementation.
-        let mut calls = Vec::new();
-        let mut pos = 0;
-
-        while let Some(start) = response[pos..].find("<tool_use>") {
-            let abs_start = pos + start;
-            let search_from = abs_start + "<tool_use>".len();
-
-            if let Some(end_offset) = response[search_from..].find("</tool_use>") {
-                let abs_end = search_from + end_offset;
-                let block = &response[search_from..abs_end];
-
-                // Extract tool_name
-                let tool_name = if let Some(name_start) = block.find("<tool_name>") {
-                    let name_content_start = name_start + "<tool_name>".len();
-                    if let Some(name_end) = block[name_content_start..].find("</tool_name>") {
-                        block[name_content_start..name_content_start + name_end]
-                            .trim()
-                            .to_string()
-                    } else {
-                        pos = abs_end + "</tool_use>".len();
-                        continue;
-                    }
-                } else {
-                    pos = abs_end + "</tool_use>".len();
-                    continue;
-                };
-
-                // Extract parameters
-                let arguments = if let Some(params_start) = block.find("<parameters>") {
-                    let params_content_start = params_start + "<parameters>".len();
-                    if let Some(params_end) = block[params_content_start..].find("</parameters>") {
-                        let params_str =
-                            block[params_content_start..params_content_start + params_end].trim();
-                        // Try to parse as JSON, fallback to empty object
-                        serde_json::from_str(params_str).unwrap_or(serde_json::json!({}))
-                    } else {
-                        serde_json::json!({})
-                    }
-                } else {
-                    serde_json::json!({})
-                };
-
-                calls.push(ToolCall {
-                    id: format!("tool_{}", calls.len() + 1),
-                    name: tool_name,
-                    arguments,
-                });
-
-                pos = abs_end + "</tool_use>".len();
-            } else {
-                break;
-            }
-        }
-
-        calls
-    }
+    // extract_tool_calls removed: tool calls now come directly from StreamEvent::ToolCall
 
     /// Estimate request tokens (rough heuristic: 4 chars per token)
     fn estimate_request_tokens(&self, messages: &[ProviderMessage]) -> u64 {
@@ -449,6 +431,24 @@ pub struct ToolCall {
     pub arguments: serde_json::Value,
 }
 
+/// Accumulates typed stream events into a complete model turn.
+#[derive(Debug, Default)]
+struct TurnAccumulator {
+    text: String,
+    tool_calls: Vec<ToolCall>,
+    usage: Option<(u64, u64, bool)>, // (prompt, completion, measured)
+    finish_reason: Option<FinishReason>,
+}
+
+/// Result of a model turn with structured data.
+#[derive(Debug)]
+struct ModelTurnResult {
+    text: String,
+    tool_calls: Vec<ToolCall>,
+    #[allow(dead_code)] // Used for future usage tracking
+    measured_usage: Option<(u64, u64)>, // (prompt_tokens, completion_tokens)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -462,137 +462,7 @@ mod tests {
         const { assert!(MAX_ITERATIONS <= 100) };
     }
 
-    #[test]
-    fn extract_tool_calls_single_call() {
-        let response = r#"
-Some reasoning text here.
-<tool_use>
-<tool_name>bash</tool_name>
-<parameters>{"command": "ls -la"}</parameters>
-</tool_use>
-More text after.
-"#;
-
-        let store = Arc::new(crate::MemoryEventStore::default());
-        let workspace = std::env::temp_dir();
-        let scope = crate::SandboxScope {
-            workspace_root: workspace.clone(),
-            allow_network: false,
-            allowed_hosts: vec![],
-        };
-        let policy = PolicyEngine::new(scope);
-        let runtime = Arc::new(AgentRuntime::new(store, policy.clone()));
-        let agent_loop = AgentLoop::new(runtime);
-
-        let calls = agent_loop.extract_tool_calls(response);
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].name, "bash");
-        assert_eq!(calls[0].arguments["command"], "ls -la");
-    }
-
-    #[test]
-    fn extract_tool_calls_multiple_calls() {
-        let response = r#"
-<tool_use>
-<tool_name>read_file</tool_name>
-<parameters>{"path": "src/main.rs"}</parameters>
-</tool_use>
-
-<tool_use>
-<tool_name>bash</tool_name>
-<parameters>{"command": "cargo test"}</parameters>
-</tool_use>
-"#;
-
-        let store = Arc::new(crate::MemoryEventStore::default());
-        let workspace = std::env::temp_dir();
-        let scope = crate::SandboxScope {
-            workspace_root: workspace.clone(),
-            allow_network: false,
-            allowed_hosts: vec![],
-        };
-        let policy = PolicyEngine::new(scope);
-        let runtime = Arc::new(AgentRuntime::new(store, policy.clone()));
-        let agent_loop = AgentLoop::new(runtime);
-
-        let calls = agent_loop.extract_tool_calls(response);
-        assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].name, "read_file");
-        assert_eq!(calls[1].name, "bash");
-    }
-
-    #[test]
-    fn extract_tool_calls_no_calls() {
-        let response = "Just a plain text response with no tool calls.";
-
-        let store = Arc::new(crate::MemoryEventStore::default());
-        let workspace = std::env::temp_dir();
-        let scope = crate::SandboxScope {
-            workspace_root: workspace.clone(),
-            allow_network: false,
-            allowed_hosts: vec![],
-        };
-        let policy = PolicyEngine::new(scope);
-        let runtime = Arc::new(AgentRuntime::new(store, policy.clone()));
-        let agent_loop = AgentLoop::new(runtime);
-
-        let calls = agent_loop.extract_tool_calls(response);
-        assert_eq!(calls.len(), 0);
-    }
-
-    #[test]
-    fn extract_tool_calls_malformed_skips() {
-        let response = r#"
-<tool_use>
-<tool_name>valid_tool</tool_name>
-<parameters>{"a": 1}</parameters>
-</tool_use>
-
-<tool_use>
-<tool_name>broken_tool
-</tool_use>
-"#;
-
-        let store = Arc::new(crate::MemoryEventStore::default());
-        let workspace = std::env::temp_dir();
-        let scope = crate::SandboxScope {
-            workspace_root: workspace.clone(),
-            allow_network: false,
-            allowed_hosts: vec![],
-        };
-        let policy = PolicyEngine::new(scope);
-        let runtime = Arc::new(AgentRuntime::new(store, policy.clone()));
-        let agent_loop = AgentLoop::new(runtime);
-
-        let calls = agent_loop.extract_tool_calls(response);
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].name, "valid_tool");
-    }
-
-    #[test]
-    fn extract_tool_calls_empty_parameters() {
-        let response = r#"
-<tool_use>
-<tool_name>no_params_tool</tool_name>
-</tool_use>
-"#;
-
-        let store = Arc::new(crate::MemoryEventStore::default());
-        let workspace = std::env::temp_dir();
-        let scope = crate::SandboxScope {
-            workspace_root: workspace.clone(),
-            allow_network: false,
-            allowed_hosts: vec![],
-        };
-        let policy = PolicyEngine::new(scope);
-        let runtime = Arc::new(AgentRuntime::new(store, policy.clone()));
-        let agent_loop = AgentLoop::new(runtime);
-
-        let calls = agent_loop.extract_tool_calls(response);
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].name, "no_params_tool");
-        assert_eq!(calls[0].arguments, serde_json::json!({}));
-    }
+    // extract_tool_calls tests removed: tool calls now come from StreamEvent::ToolCall
 
     #[tokio::test]
     async fn read_observation_is_returned_to_the_next_model_turn() {
@@ -614,9 +484,10 @@ More text after.
             "scripted",
             "test",
             [
-                vec![MockStreamItem::Chunk {
-                    chunk_id: 1,
-                    text: "<tool_use><tool_name>read_file</tool_name><parameters>{\"path\":\"evidence.txt\"}</parameters></tool_use>".into(),
+                vec![MockStreamItem::ToolCall {
+                    id: "call_1".to_string(),
+                    tool: "read_file".to_string(),
+                    arguments: r#"{"path":"evidence.txt"}"#.to_string(),
                 }],
                 vec![MockStreamItem::Chunk {
                     chunk_id: 2,

--- a/crates/impetus-core/src/lib.rs
+++ b/crates/impetus-core/src/lib.rs
@@ -125,7 +125,7 @@ pub use provider::{
     ProviderError, ProviderHealth, ProviderMessage, ProviderProfile, RetryBudget,
 };
 pub use provider_registry::ProviderRegistry;
-pub use provider_trait::ModelProvider;
+pub use provider_trait::{FinishReason, ModelProvider, StreamEvent};
 pub use reference_store::{
     DatasetManifest, DatasetScope, ImportResult as ReferenceImportResult, PartitionStrategy,
     RecordProvenance, RecordSource, ReferenceRecord, ReferenceService, SearchFilters, SearchResult,

--- a/crates/impetus-core/src/mock_provider.rs
+++ b/crates/impetus-core/src/mock_provider.rs
@@ -2,7 +2,9 @@
 //!
 //! Returns pre-configured streaming responses without network calls.
 
-use crate::{ModelProvider, ProviderError, ProviderHealth, ProviderMessage};
+use crate::{
+    FinishReason, ModelProvider, ProviderError, ProviderHealth, ProviderMessage, StreamEvent,
+};
 use async_trait::async_trait;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
@@ -10,11 +12,31 @@ use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MockStreamItem {
-    Chunk { chunk_id: u32, text: String },
-    ToolCall { tool: String, arguments: String },
-    Error { message: String },
-    TransientError { message: String },
-    PermanentError { message: String },
+    Chunk {
+        chunk_id: u32,
+        text: String,
+    },
+    ToolCall {
+        id: String,
+        tool: String,
+        arguments: String,
+    },
+    Usage {
+        prompt_tokens: u64,
+        completion_tokens: u64,
+    },
+    Finish {
+        reason: FinishReason,
+    },
+    Error {
+        message: String,
+    },
+    TransientError {
+        message: String,
+    },
+    PermanentError {
+        message: String,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -96,7 +118,7 @@ impl ModelProvider for MockProvider {
         _credential: Option<&str>,
         _runtime: Option<Arc<crate::AgentRuntime>>,
         cancel: CancellationToken,
-        mut on_chunk: Box<dyn FnMut(String) -> Result<(), ProviderError> + Send>,
+        mut on_event: Box<dyn FnMut(StreamEvent) -> Result<(), ProviderError> + Send>,
     ) -> Result<(), ProviderError> {
         if let Ok(mut received) = self.received_messages.lock() {
             received.push(messages.to_vec());
@@ -114,11 +136,36 @@ impl ModelProvider for MockProvider {
 
             match item {
                 MockStreamItem::Chunk { text, .. } => {
-                    on_chunk(text.clone())?;
+                    on_event(StreamEvent::TextDelta {
+                        delta: text.clone(),
+                    })?;
                 }
-                MockStreamItem::ToolCall { .. } => {
-                    // Tool calls will be handled in future implementation
-                    continue;
+                MockStreamItem::ToolCall {
+                    id,
+                    tool,
+                    arguments,
+                } => {
+                    // Parse arguments as JSON, fail if invalid
+                    let args = serde_json::from_str(arguments)
+                        .map_err(|_| ProviderError::MalformedStream)?;
+                    on_event(StreamEvent::ToolCall {
+                        id: id.clone(),
+                        name: tool.clone(),
+                        arguments: args,
+                    })?;
+                }
+                MockStreamItem::Usage {
+                    prompt_tokens,
+                    completion_tokens,
+                } => {
+                    on_event(StreamEvent::Usage {
+                        prompt_tokens: *prompt_tokens,
+                        completion_tokens: *completion_tokens,
+                        measured: true,
+                    })?;
+                }
+                MockStreamItem::Finish { reason } => {
+                    on_event(StreamEvent::Finish { reason: *reason })?;
                 }
                 MockStreamItem::Error { message } => {
                     return Err(ProviderError::RequestFailed(message.clone()));

--- a/crates/impetus-core/src/openai_compat_adapter.rs
+++ b/crates/impetus-core/src/openai_compat_adapter.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     CredentialResolver, ModelProvider, OpenAiCompatibleProvider, ProviderError, ProviderHealth,
-    ProviderMessage,
+    ProviderMessage, StreamEvent,
 };
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -56,7 +56,7 @@ impl ModelProvider for OpenAiCompatibleAdapter {
         _credential: Option<&str>,
         _runtime: Option<Arc<crate::AgentRuntime>>,
         cancel: CancellationToken,
-        on_chunk: Box<dyn FnMut(String) -> Result<(), ProviderError> + Send>,
+        mut on_event: Box<dyn FnMut(StreamEvent) -> Result<(), ProviderError> + Send>,
     ) -> Result<(), ProviderError> {
         let credential = self
             .credential_resolver
@@ -64,7 +64,12 @@ impl ModelProvider for OpenAiCompatibleAdapter {
             .map_err(|_| ProviderError::MissingCredential)?;
 
         self.provider
-            .stream_messages(messages, credential.as_deref(), cancel, on_chunk)
+            .stream_messages(
+                messages,
+                credential.as_deref(),
+                cancel,
+                Box::new(move |text| on_event(StreamEvent::TextDelta { delta: text })),
+            )
             .await
     }
 }

--- a/crates/impetus-core/src/openai_provider.rs
+++ b/crates/impetus-core/src/openai_provider.rs
@@ -3,7 +3,9 @@
 //! Streams chat completions through an OpenAI-compatible endpoint with
 //! retry logic and health tracking.
 
-use crate::{ModelProvider, ProviderError, ProviderHealth, ProviderMessage, ProviderProfile};
+use crate::{
+    ModelProvider, ProviderError, ProviderHealth, ProviderMessage, ProviderProfile, StreamEvent,
+};
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use reqwest::Client;
@@ -79,7 +81,7 @@ impl OpenAiProvider {
         credential: Option<&str>,
         _runtime: Option<Arc<crate::AgentRuntime>>,
         cancel: CancellationToken,
-        on_chunk: Box<dyn FnMut(String) -> Result<(), ProviderError> + Send>,
+        on_event: Box<dyn FnMut(StreamEvent) -> Result<(), ProviderError> + Send>,
     ) -> Result<(), ProviderError> {
         let url = self.chat_completions_url()?;
         let mut attempt = 0u8;
@@ -103,7 +105,7 @@ impl OpenAiProvider {
             match request.send().await {
                 Ok(response) if response.status().is_success() => {
                     self.update_health(ProviderHealth::Healthy);
-                    return self.consume_sse_stream(response, cancel, on_chunk).await;
+                    return self.consume_sse_stream(response, cancel, on_event).await;
                 }
                 Ok(response) => {
                     let status = response.status();
@@ -134,7 +136,7 @@ impl OpenAiProvider {
         &self,
         response: reqwest::Response,
         cancel: CancellationToken,
-        mut on_chunk: Box<dyn FnMut(String) -> Result<(), ProviderError> + Send>,
+        mut on_event: Box<dyn FnMut(StreamEvent) -> Result<(), ProviderError> + Send>,
     ) -> Result<(), ProviderError> {
         let mut stream = response.bytes_stream();
         let mut buffer = Vec::new();
@@ -164,7 +166,9 @@ impl OpenAiProvider {
                             && let Some(delta) = parsed.choices.first()
                             && let Some(content) = &delta.delta.content
                         {
-                            on_chunk(content.clone())?;
+                            on_event(StreamEvent::TextDelta {
+                                delta: content.clone(),
+                            })?;
                         }
                     }
                 }
@@ -200,9 +204,9 @@ impl ModelProvider for OpenAiProvider {
         credential: Option<&str>,
         runtime: Option<Arc<crate::AgentRuntime>>,
         cancel: CancellationToken,
-        on_chunk: Box<dyn FnMut(String) -> Result<(), ProviderError> + Send>,
+        on_event: Box<dyn FnMut(StreamEvent) -> Result<(), ProviderError> + Send>,
     ) -> Result<(), ProviderError> {
-        self.stream_with_retry(messages, credential, runtime, cancel, on_chunk)
+        self.stream_with_retry(messages, credential, runtime, cancel, on_event)
             .await
     }
 }

--- a/crates/impetus-core/src/provider_trait.rs
+++ b/crates/impetus-core/src/provider_trait.rs
@@ -6,9 +6,58 @@
 
 use crate::{AgentRuntime, ProviderError, ProviderHealth, ProviderMessage};
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
+
+/// Normalized streaming event from a model provider.
+///
+/// Providers parse their native protocol (OpenAI, Anthropic, etc.)
+/// into these typed events at the boundary.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StreamEvent {
+    /// Incremental text content.
+    TextDelta { delta: String },
+
+    /// Structured tool call from the model.
+    ToolCall {
+        id: String,
+        name: String,
+        arguments: serde_json::Value,
+    },
+
+    /// Token usage statistics.
+    Usage {
+        prompt_tokens: u64,
+        completion_tokens: u64,
+        /// True if measured by provider, false if heuristic estimate.
+        measured: bool,
+    },
+
+    /// Stream completion reason.
+    Finish { reason: FinishReason },
+
+    /// Provider-specific reasoning trace (e.g., Claude thinking).
+    Reasoning { content: String },
+}
+
+/// Why the model stopped generating.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FinishReason {
+    /// Natural completion.
+    Stop,
+    /// Hit token limit.
+    Length,
+    /// Model wants to call tools.
+    ToolCalls,
+    /// Content filter triggered.
+    ContentFilter,
+    /// Other provider-specific reason.
+    Other,
+}
 
 /// Unified interface for streaming chat completion providers.
 ///
@@ -29,7 +78,7 @@ pub trait ModelProvider: Send + Sync + Debug {
     /// The `credential` parameter is resolved transiently by the harness
     /// and never persisted. Implementations must not retain it.
     ///
-    /// The `on_chunk` callback receives each streamed text chunk.
+    /// The `on_event` callback receives each typed stream event.
     /// Return `Err` from the callback to stop streaming.
     async fn stream_messages(
         &self,
@@ -37,6 +86,6 @@ pub trait ModelProvider: Send + Sync + Debug {
         credential: Option<&str>,
         runtime: Option<Arc<AgentRuntime>>,
         cancel: CancellationToken,
-        on_chunk: Box<dyn FnMut(String) -> Result<(), ProviderError> + Send>,
+        on_event: Box<dyn FnMut(StreamEvent) -> Result<(), ProviderError> + Send>,
     ) -> Result<(), ProviderError>;
 }


### PR DESCRIPTION
## Summary

Implements structured stream events for provider-native tool calling, replacing XML regex parsing with typed protocol boundaries.

## Changes

### Core Infrastructure
- Added `StreamEvent` enum with typed variants:
  - `TextDelta` - incremental text content
  - `ToolCall { id, name, arguments }` - structured tool invocation
  - `Usage { prompt_tokens, completion_tokens, measured }` - token accounting
  - `Finish { reason }` - completion status
  - `Reasoning { content }` - provider reasoning traces
- Updated `ModelProvider::stream_messages` signature to emit typed events
- Added `FinishReason` enum (Stop, Length, ToolCalls, ContentFilter, Other)

### Provider Updates
- **MockProvider**: Generates structured `ToolCall` events, validates JSON arguments
- **OpenAiProvider**: Parses SSE into `TextDelta` events (tool call parsing pending)
- **ACP/OpenAI-compat adapters**: Wrap text chunks in `TextDelta` events

### AgentLoop Refactoring
- Removed XML-based `extract_tool_calls` parser and related tests
- Refactored `call_model` to accumulate typed events into `ModelTurnResult`
- Tool calls now come directly from provider `StreamEvent::ToolCall`
- Fixed potential deadlock by minimizing accumulator lock scope
- Token usage prefers measured values, falls back to estimation

## Testing
- 392 tests passing (unit + integration)
- Pre-existing harness_api test hangs are unrelated (reproduced on main)
- cargo fmt, clippy, check all pass

## Remaining Work (tracked in #83)
- [ ] Parse native OpenAI/Anthropic tool call protocol
- [ ] Validate tool arguments before execution (reject malformed)
- [ ] Track measured vs estimated usage in budget events
- [ ] Add tests for multiple provider response shapes
- [ ] Preserve tool call IDs through observation lifecycle

## References
- Closes #83 (partial - foundation complete, protocol parsing pending)
- Task 08: `impetus_next_prompts/08_PROVIDER_NATIVE_TOOL_CALLS_AND_USAGE.md`
