### PR TITLE
feat: complete web research task with policies and probes (closes #90)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -133,7 +133,7 @@ Details: [ARCHITECTURE.md](ARCHITECTURE.md) § Web / Internet Research.
 - [x] `WebFetchService` (separate from search)
 - [x] `BrowserService` + `BrowserProvider` contract (optional module)
 - [x] Agent Loop integration via contracts only (no direct DuckDuckGo/Bing deps)
-- [ ] Research loop: search → select → fetch → follow links → compare → cite
+- [x] Research loop: search → select → fetch → follow links → compare → cite
 
 ### WebSearch backends
 
@@ -160,7 +160,7 @@ Details: [ARCHITECTURE.md](ARCHITECTURE.md) § Web / Internet Research.
 
 ### Safety & policy
 
-- [ ] Fine-grained capabilities: `web.read`, `web.search`, `web.download`, `web.browser`, `web.submit`, `web.upload`
+- [x] Fine-grained capabilities: `web.read`, `web.search`, `web.download`, `web.browser`, `web.submit`, `web.upload`
 - [ ] Session-level allowance for read-only web vs stricter approval for outbound data (POST, upload, auth actions)
 - [x] SSRF: block localhost, `127.0.0.0/8`, `::1`, private LAN, link-local, metadata endpoints, local services
 - [x] Validate initial URL, DNS resolution, redirect chain, final destination
@@ -184,8 +184,8 @@ Upstream: `https://github.com/1jehuang/jcode` — pin SHA before implementation.
 ### Doctor
 
 - [x] Internet access enabled/disabled
-- [ ] WebFetch / per-SearchBackend / BrowserProvider health in `impetus doctor`
-- [ ] `DEGRADED — web search fallback available` when fallback path works
+- [x] WebFetch / per-SearchBackend / BrowserProvider health in `impetus doctor`
+- [x] `DEGRADED — web search fallback available` when fallback path works
 
 ---
 

--- a/crates/impetus-core/src/harness_api.rs
+++ b/crates/impetus-core/src/harness_api.rs
@@ -1034,6 +1034,18 @@ fn compute_approval_detail(
         ActionKind::TmuxAttach => {
             estimated_scope = Some(ScopeEstimate::Operations(1));
         }
+        ActionKind::WebSearch
+        | ActionKind::WebFetch
+        | ActionKind::WebDownload
+        | ActionKind::WebBrowser
+        | ActionKind::WebSubmit
+        | ActionKind::WebUpload => {
+            // Web operations: note target URL
+            if let Some(target) = &request.action.target {
+                affected_files.push(target.clone());
+                estimated_scope = Some(ScopeEstimate::Operations(1));
+            }
+        }
     }
 
     Ok(crate::ApprovalDetail {

--- a/crates/impetus-core/src/policy.rs
+++ b/crates/impetus-core/src/policy.rs
@@ -48,6 +48,12 @@ pub enum ActionKind {
     SshConnect,
     SftpTransfer,
     TmuxAttach,
+    WebSearch,
+    WebFetch,
+    WebDownload,
+    WebBrowser,
+    WebSubmit,
+    WebUpload,
 }
 
 impl ActionKind {
@@ -62,6 +68,12 @@ impl ActionKind {
             ActionKind::SshConnect => ExecutionSemantics::NonReplayable,
             ActionKind::SftpTransfer => ExecutionSemantics::Mutating,
             ActionKind::TmuxAttach => ExecutionSemantics::NonReplayable,
+            ActionKind::WebSearch => ExecutionSemantics::Idempotent,
+            ActionKind::WebFetch => ExecutionSemantics::ReadOnly,
+            ActionKind::WebDownload => ExecutionSemantics::Mutating,
+            ActionKind::WebBrowser => ExecutionSemantics::NonReplayable,
+            ActionKind::WebSubmit => ExecutionSemantics::Mutating,
+            ActionKind::WebUpload => ExecutionSemantics::Mutating,
         }
     }
 
@@ -216,6 +228,30 @@ impl PolicyEngine {
                 } else {
                     PolicyDecision::NeedsApproval {
                         reason: "opens a network connection".into(),
+                    }
+                }
+            }
+            ActionKind::WebSearch | ActionKind::WebFetch => {
+                if !self.scope.allow_network {
+                    PolicyDecision::Deny {
+                        reason: "network is disabled in this workspace scope".into(),
+                    }
+                } else {
+                    PolicyDecision::Allow
+                }
+            }
+            ActionKind::WebDownload
+            | ActionKind::WebBrowser
+            | ActionKind::WebSubmit
+            | ActionKind::WebUpload => {
+                if !self.scope.allow_network {
+                    PolicyDecision::Deny {
+                        reason: "network is disabled in this workspace scope".into(),
+                    }
+                } else {
+                    PolicyDecision::NeedsApproval {
+                        reason: "performs web operation that may change state or transfer data"
+                            .into(),
                     }
                 }
             }

--- a/crates/impetus-core/src/web_research/mod.rs
+++ b/crates/impetus-core/src/web_research/mod.rs
@@ -1,6 +1,6 @@
 mod bing;
 mod browser;
-mod doctor;
+pub mod doctor;
 mod duckduckgo;
 mod html;
 mod http;

--- a/crates/impetus/src/doctor.rs
+++ b/crates/impetus/src/doctor.rs
@@ -110,7 +110,7 @@ impl DoctorReport {
     }
 }
 
-pub async fn run_diagnostics(socket_path: &str, json: bool) -> Result<()> {
+pub async fn run_diagnostics(socket_path: &str, json: bool, probe_network: bool) -> Result<()> {
     let mut report = DoctorReport::new();
 
     // Probe: impetus/impetusd versions
@@ -120,7 +120,7 @@ pub async fn run_diagnostics(socket_path: &str, json: bool) -> Result<()> {
     probe_socket(&mut report, socket_path);
 
     // Probe: daemon connection and protocol compatibility
-    probe_daemon_connection(&mut report, socket_path).await;
+    probe_daemon_connection(&mut report, socket_path, probe_network).await;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
@@ -196,7 +196,11 @@ fn probe_socket(report: &mut DoctorReport, socket_path: &str) {
     }
 }
 
-async fn probe_daemon_connection(report: &mut DoctorReport, socket_path: &str) {
+async fn probe_daemon_connection(
+    report: &mut DoctorReport,
+    socket_path: &str,
+    probe_network: bool,
+) {
     match impetus_client::UnixSocketTransport::connect(socket_path).await {
         Ok(client) => {
             report.add(ProbeResult::ok(
@@ -286,6 +290,11 @@ async fn probe_daemon_connection(report: &mut DoctorReport, socket_path: &str) {
             match client.request(impetus_core::IpcRequest::Diagnostics).await {
                 Ok(impetus_core::IpcResponse::Diagnostics { subsystems }) => {
                     add_subsystem_probes(report, *subsystems);
+
+                    // Live network probe if requested
+                    if probe_network {
+                        probe_web_research_live(report).await;
+                    }
                 }
                 Ok(other) => {
                     report.add(ProbeResult::warn(
@@ -352,6 +361,72 @@ fn add_subsystem_probes(report: &mut DoctorReport, subsystems: impetus_core::Sub
     ));
     report.add(status_to_probe("disk_runtime", subsystems.disk_runtime));
     report.add(status_to_probe("web_research", subsystems.web_research));
+}
+
+async fn probe_web_research_live(report: &mut DoctorReport) {
+    use impetus_core::web_research::{EgressPolicy, WebDoctor, WebResearchEngine};
+
+    let engine = WebResearchEngine::production(EgressPolicy::default());
+    let web_report = WebDoctor::probe_engine(&engine).await;
+
+    // Add per-backend probes
+    for backend in &web_report.search_backends {
+        let (status, message, remediation) = match &backend.status {
+            impetus_core::web_research::doctor::BackendDoctorStatus::BuiltIn => (
+                ProbeStatus::Ok,
+                "Built-in backend available".to_string(),
+                None,
+            ),
+            impetus_core::web_research::doctor::BackendDoctorStatus::Configured => (
+                ProbeStatus::Ok,
+                "External backend configured".to_string(),
+                None,
+            ),
+            impetus_core::web_research::doctor::BackendDoctorStatus::Reachable => (
+                ProbeStatus::Ok,
+                "Search backend reachable".to_string(),
+                None,
+            ),
+            impetus_core::web_research::doctor::BackendDoctorStatus::Unavailable { reason } => (
+                ProbeStatus::Unavailable,
+                format!("Backend unavailable: {}", reason),
+                Some("Check network policy or firewall settings".to_string()),
+            ),
+            impetus_core::web_research::doctor::BackendDoctorStatus::Misconfigured { reason } => (
+                ProbeStatus::Error,
+                format!("Backend misconfigured: {}", reason),
+                Some("Check backend configuration".to_string()),
+            ),
+            impetus_core::web_research::doctor::BackendDoctorStatus::Failed { reason } => (
+                ProbeStatus::Error,
+                format!("Backend probe failed: {}", reason),
+                Some("Check network connectivity and backend availability".to_string()),
+            ),
+        };
+
+        let probe = ProbeResult {
+            name: format!("web_backend_{}", backend.id),
+            status,
+            message,
+            remediation,
+            details: None,
+        };
+
+        report.add(probe);
+    }
+
+    // Add summary notes
+    if !web_report.notes.is_empty() {
+        for note in &web_report.notes {
+            if note.contains("DEGRADED") {
+                report.add(ProbeResult::warn(
+                    "web_research_status",
+                    note.clone(),
+                    "Primary backend unavailable, fallback active",
+                ));
+            }
+        }
+    }
 }
 
 fn print_compatibility_matrix() {

--- a/crates/impetus/src/main.rs
+++ b/crates/impetus/src/main.rs
@@ -34,6 +34,9 @@ enum Commands {
         /// Output in JSON format
         #[arg(long)]
         json: bool,
+        /// Perform live network probes (web search backends, internet access)
+        #[arg(long)]
+        probe_network: bool,
     },
     /// Inspect registered components and modules
     Components {
@@ -127,8 +130,11 @@ async fn main() -> Result<()> {
     let socket_path = daemon::discover_socket_path();
 
     match cli.command {
-        Commands::Doctor { json } => {
-            doctor::run_diagnostics(&socket_path, json).await?;
+        Commands::Doctor {
+            json,
+            probe_network,
+        } => {
+            doctor::run_diagnostics(&socket_path, json, probe_network).await?;
             return Ok(());
         }
         Commands::Components { action } => {


### PR DESCRIPTION
- Add fine-grained web capabilities to ActionKind: WebSearch, WebFetch, WebDownload, WebBrowser, WebSubmit, WebUpload
- WebSearch/WebFetch are read-only and auto-approved when network enabled
- WebDownload/WebBrowser/WebSubmit/WebUpload require approval (mutating/state-changing)
- Add --probe-network flag to 'impetus doctor' for live web backend health checks
- Expose web_research::doctor module publicly for client integration
- Live probe reports per-backend status (Reachable/Unavailable/Failed) and DEGRADED state when fallback active
- Research loop implementation already complete (search → fetch → follow links → citations)
- All web capabilities integrated with policy engine and harness approval flow
