### PR TITLE
ci: optimize Rust workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,8 +2,11 @@ name: Rust CI
 
 on:
   pull_request:
-  push:
-    branches: [main]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - '.github/workflows/check.yml'
   workflow_dispatch:
 
 permissions:
@@ -14,69 +17,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  fmt:
-    name: Format
-    runs-on: macos-14
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.98.0
-        with:
-          components: rustfmt
-      - run: cargo fmt --all -- --check
-
-  test:
-    name: Test
-    runs-on: macos-14
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.98.0
-      - uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: macos-rust-1.98-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            macos-rust-1.98-
-      - run: cargo test --workspace
-
-  check:
-    name: Check
-    runs-on: macos-14
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.98.0
-      - uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: macos-rust-1.98-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            macos-rust-1.98-
-      - run: cargo check --workspace
-
-  clippy:
-    name: Clippy
+  rust:
+    name: Rust checks
     runs-on: macos-14
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.98.0
         with:
-          components: clippy
-      - uses: actions/cache@v6
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: macos-rust-1.98-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            macos-rust-1.98-
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+          cache-targets: "false"
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Lint workspace
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Run unit tests
+        run: cargo test --workspace --lib --bins

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,26 @@
+name: Rust integration
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-integration-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    name: Full workspace tests
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.98.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: "false"
+      - run: cargo test --workspace

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,8 @@ name: Deploy landing page
 on:
   push:
     branches: [main]
+    paths:
+      - 'site/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,35 @@
+name: Dependency security
+
+on:
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'deny.toml'
+      - '.github/workflows/security.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  security:
+    name: Cargo audit and deny
+    runs-on: macos-14
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.98.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: "false"
+      - name: Install dependency security tools
+        run: cargo install cargo-audit --locked && cargo install cargo-deny --locked
+      - name: Audit dependencies
+        run: cargo audit
+      - name: Check dependency policy
+        run: cargo deny check advisories bans sources licenses

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,9 @@ jobs:
         with:
           cache-targets: "false"
       - name: Install dependency security tools
-        run: cargo install cargo-audit --locked && cargo install cargo-deny --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit,cargo-deny
       - name: Audit dependencies
         run: cargo audit
       - name: Check dependency policy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,9 @@ For harness/provider/ACP/auth changes, add test without secrets: stream/cancel/r
 ## CI and Verification
 
 - Before handoff of Rust changes, execute `task verify` (locally).
-- **CI test scope:** `cargo test --lib --bins` (unit tests only). Integration tests from `crates/*/tests/` excluded — they require macOS Seatbelt, native environment, and compile slowly in Docker. Locally run full `task verify` with integration tests.
+- **PR Rust CI:** one macOS job runs `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace --lib --bins`; Clippy replaces a separate CI `cargo check`. Rust CI runs only for Rust/workflow changes and does not rerun on `main` after a merged PR.
+- **Integration CI:** `cargo test --workspace` runs only from the manual/nightly macOS workflow. Integration tests from `crates/*/tests/` stay outside the PR path because they require macOS Seatbelt and compile slowly in Docker. Locally run full `task verify` with integration tests.
+- **Dependency security CI:** `cargo audit` and `cargo deny` run only when `Cargo.toml`, `Cargo.lock`, `deny.toml`, or their workflow changes. Pages runs only for `site/**` changes.
 - On `Cargo.toml` or `Cargo.lock` changes, execute `task security`; do not ignore RustSec/CVE, license/source/bans findings without versioned entry in `deny.toml` with specific reason.
 
 ## Git and Commits
@@ -94,7 +96,7 @@ For harness/provider/ACP/auth changes, add test without secrets: stream/cancel/r
    ```
    Or via GitHub Web UI
 6. **Enable auto-merge** in PR: `gh pr merge --auto --squash` after creation
-7. CI passes (fmt, test, check, clippy) → **GitHub auto-merges to main**
+7. Required PR CI passes → **GitHub auto-merges to main**
 8. After merge: `git checkout main && git pull` for next task
 
 #### Auto-merge Setup (once per project)

--- a/crates/impetus-core/src/harness_api.rs
+++ b/crates/impetus-core/src/harness_api.rs
@@ -1604,13 +1604,15 @@ mod tests {
             "scripted",
             "test-model",
             [
-                vec![MockStreamItem::Chunk {
-                    chunk_id: 1,
-                    text: "<tool_use><tool_name>read_file</tool_name><parameters>{\"path\":\"evidence.txt\"}</parameters></tool_use>".into(),
+                vec![MockStreamItem::ToolCall {
+                    id: "read-evidence".into(),
+                    tool: "read_file".into(),
+                    arguments: r#"{"path":"evidence.txt"}"#.into(),
                 }],
-                vec![MockStreamItem::Chunk {
-                    chunk_id: 1,
-                    text: "<tool_use><tool_name>write_file</tool_name><parameters>{\"path\":\"result.txt\",\"content\":\"approved result\"}</parameters></tool_use>".into(),
+                vec![MockStreamItem::ToolCall {
+                    id: "write-result".into(),
+                    tool: "write_file".into(),
+                    arguments: r#"{"path":"result.txt","content":"approved result"}"#.into(),
                 }],
                 vec![MockStreamItem::Chunk {
                     chunk_id: 1,
@@ -1713,9 +1715,10 @@ mod tests {
             "scripted-rejection",
             "test-model",
             [
-                vec![MockStreamItem::Chunk {
-                    chunk_id: 1,
-                    text: "<tool_use><tool_name>write_file</tool_name><parameters>{\"path\":\"blocked.txt\",\"content\":\"must not write\"}</parameters></tool_use>".into(),
+                vec![MockStreamItem::ToolCall {
+                    id: "write-blocked".into(),
+                    tool: "write_file".into(),
+                    arguments: r#"{"path":"blocked.txt","content":"must not write"}"#.into(),
                 }],
                 vec![MockStreamItem::Chunk {
                     chunk_id: 1,
@@ -1737,23 +1740,26 @@ mod tests {
             session_id,
             text: "try the write".into(),
         });
-        let approval_id = loop {
+        let mut approval_id = None;
+        for _ in 0..100 {
             let IpcResponse::Events { events, .. } = harness.handle(IpcRequest::Stream {
                 session_id,
                 after_sequence: 0,
             }) else {
                 panic!("event stream")
             };
-            if let Some(approval_id) = events.iter().find_map(|event| match &event.payload {
+            approval_id = events.iter().find_map(|event| match &event.payload {
                 EventPayload::Approval(crate::ApprovalEvent::Requested { request }) => {
                     Some(request.id)
                 }
                 _ => None,
-            }) {
-                break approval_id;
+            });
+            if approval_id.is_some() {
+                break;
             }
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        };
+        }
+        let approval_id = approval_id.expect("write approval");
         assert!(matches!(
             harness.handle(IpcRequest::ResolveApproval {
                 session_id,

--- a/crates/test-module/Cargo.toml
+++ b/crates/test-module/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test-module"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 publish = false
 
 [[bin]]


### PR DESCRIPTION
Closes #95

- consolidate PR Rust validation into one path-scoped job
- run workspace unit and binary tests on PRs; move full tests to manual/nightly
- run dependency security and Pages only for relevant paths
- replace broad target caching with registry/tool caching
- update stale approval/resume fixtures and bound approval polling